### PR TITLE
Extend IActionStrategy with property-level action validation

### DIFF
--- a/src/Mpt.Rql.Abstractions/IActionStrategy.cs
+++ b/src/Mpt.Rql.Abstractions/IActionStrategy.cs
@@ -1,7 +1,10 @@
 #pragma warning disable IDE0130
+using Mpt.Rql.Abstractions;
+
 namespace Mpt.Rql;
 
 public interface IActionStrategy
 {
     bool IsAllowed(RqlActions action);
+    bool IsAllowed(RqlActions action, IRqlPropertyInfo property) => IsAllowed(action);
 }

--- a/src/Mpt.Rql/Core/ActionValidator.cs
+++ b/src/Mpt.Rql/Core/ActionValidator.cs
@@ -13,7 +13,7 @@ internal class ActionValidator(IExternalServiceAccessor externalServices) : IAct
                     $"The instance of type {propertyInfo.ActionStrategy.FullName} defined as action strategy for property " +
                     $"({propertyInfo.Property!.DeclaringType!.FullName}).{propertyInfo.Property.Name} " +
                     $"cannot be found. Make sure that service has been registered.")
-                : strategy.IsAllowed(action);
+                : strategy.IsAllowed(action, propertyInfo);
         }
 
         return propertyInfo.Actions.HasFlag(action);


### PR DESCRIPTION
Summary

  - Adds a new IsAllowed(RqlActions action, IRqlPropertyInfo property) overload to IActionStrategy as a default interface method (DIM), preserving backward compatibility
  - Updates ActionValidator to call the new overload, passing property metadata to the strategy

Motivation

The existing IActionStrategy.IsAllowed(RqlActions action) only receives the action type, making authorization decisions purely based on the user context (e.g., "is this user Operations?"). There was no way for a strategy to make decisions based on which property is being accessed.

This becomes necessary when a consuming application needs to override visibility rules on a per-property basis. For example, a module may want to mark certain Ops-only properties as visible to all account types while still respecting the property's Actions flags (Select, Filter, Order). Without property context in the strategy, this granularity is impossible — the strategy must either allow or deny all actions uniformly.

Changes

  - IActionStrategy.cs — Added IsAllowed(RqlActions action, IRqlPropertyInfo property) with a default implementation that delegates to the existing IsAllowed(RqlActions action), ensuring all existing strategy implementations continue to work without modification.
  - ActionValidator.cs — Changed strategy.IsAllowed(action) → strategy.IsAllowed(action, propertyInfo) to pass the property info through to the strategy.

Backward Compatibility

Fully backward compatible. The new method is a default interface method — existing IActionStrategy implementations are not required to implement it and will automatically fall back to the original behavior.