### PR TITLE
Introduce orderby() ordering function for collection-based sort keys

### DIFF
--- a/src/Mpt.Rql/Core/PathInfoBuilder.cs
+++ b/src/Mpt.Rql/Core/PathInfoBuilder.cs
@@ -5,6 +5,7 @@ using Mpt.Rql.Abstractions.Result;
 using Mpt.Rql.Core.Metadata;
 using Mpt.Rql.Services.Context;
 using System.Linq.Expressions;
+using System.Reflection;
 
 namespace Mpt.Rql.Core;
 
@@ -47,8 +48,9 @@ internal abstract class PathInfoBuilder(IMetadataProvider metadataProvider, IBui
         var pathExpression = root;
         var currentPathLength = 0;
 
-        foreach (var segment in nameSegments)
+        for (int i = 0; i < nameSegments.Length; i++)
         {
+            var segment = nameSegments[i];
             if (currentPathLength > 0)
                 currentPathLength++; // account for dot
 
@@ -64,6 +66,12 @@ internal abstract class PathInfoBuilder(IMetadataProvider metadataProvider, IBui
 
             if (validationResult.IsError)
                 return validationResult.Errors;
+
+            // When a collection property has remaining segments, pivot into inner path via Select().FirstOrDefault()
+            if (propInfo.Type == RqlPropertyType.Collection && i < nameSegments.Length - 1)
+            {
+                return BuildCollectionInnerPath(propInfo, pathExpression, nameSegments, i, memberAccess);
+            }
 
             currentType = propInfo.Property.PropertyType;
             pathExpression = Expression.MakeMemberAccess(pathExpression, propInfo!.Property!);
@@ -81,6 +89,94 @@ internal abstract class PathInfoBuilder(IMetadataProvider metadataProvider, IBui
         }
 
         return new MemberPathInfo(propInfo!, pathExpression);
+    }
+
+    private Result<MemberPathInfo> BuildCollectionInnerPath(
+        RqlPropertyInfo collectionProperty,
+        Expression parentExpression,
+        string[] nameSegments,
+        int collectionIndex,
+        List<Expression>? priorMemberAccess)
+    {
+        var collectionExpression = Expression.MakeMemberAccess(parentExpression, collectionProperty.Property);
+        var elementType = collectionProperty.ElementType!;
+        var innerParam = Expression.Parameter(elementType);
+        var remainingPath = string.Join(".", nameSegments.Skip(collectionIndex + 1));
+
+        var innerResult = Build(innerParam, remainingPath);
+        if (innerResult.IsError)
+            return innerResult.Errors;
+
+        var innerExpression = innerResult.Value!.Expression;
+        var innerPropertyInfo = innerResult.Value.PropertyInfo;
+
+        // For value types, use a nullable selector so FirstOrDefault() returns null for empty collections
+        // rather than the default value (e.g. 0 for int), which ensures correct null ordering semantics
+        var selectorResultType = innerExpression.Type;
+        Expression selectorBody = innerExpression;
+        if (selectorResultType.IsValueType && Nullable.GetUnderlyingType(selectorResultType) == null)
+        {
+            selectorResultType = typeof(Nullable<>).MakeGenericType(selectorResultType);
+            selectorBody = Expression.Convert(innerExpression, selectorResultType);
+        }
+
+        var selectLambda = Expression.Lambda(selectorBody, innerParam);
+        var selectMethod = GetSelectMethod(elementType, selectorResultType);
+        var firstOrDefaultMethod = GetFirstOrDefaultMethod(selectorResultType);
+
+        var selectCall = Expression.Call(null, selectMethod, collectionExpression, selectLambda);
+        Expression finalExpr = Expression.Call(null, firstOrDefaultMethod, selectCall);
+
+        if (UseSafeNavigation())
+            finalExpr = WrapWithCollectionNullCheck(collectionExpression, finalExpr, priorMemberAccess);
+
+        return new MemberPathInfo(innerPropertyInfo, finalExpr);
+    }
+
+    private static Expression WrapWithCollectionNullCheck(
+        Expression collectionExpression,
+        Expression valueExpression,
+        List<Expression>? priorMemberAccess)
+    {
+        var resultType = valueExpression.Type;
+
+        // Build the condition: full safe-navigation chain including the collection,
+        // or just the collection itself when there are no pre-collection references.
+        // If any ancestor or the collection itself is null, the condition evaluates to null
+        // and we short-circuit, preventing NullReferenceException on the Select() call.
+        Expression conditionExpr;
+        if (priorMemberAccess != null && priorMemberAccess.Count > 0)
+        {
+            var withCollection = new List<Expression>(priorMemberAccess) { collectionExpression };
+            conditionExpr = BuildConditionalExpression(withCollection, 0);
+        }
+        else
+        {
+            conditionExpr = collectionExpression;
+        }
+
+        return Expression.Condition(
+            Expression.Equal(conditionExpr, Expression.Constant(null, conditionExpr.Type)),
+            Expression.Constant(null, resultType),
+            valueExpression);
+    }
+
+    private static MethodInfo GetSelectMethod(Type elementType, Type resultType)
+    {
+        return typeof(Enumerable)
+            .GetMethods(BindingFlags.Static | BindingFlags.Public)
+            .Where(m => m.Name == nameof(Enumerable.Select) && m.GetParameters().Length == 2)
+            .First(m => m.GetParameters()[1].ParameterType.GetGenericArguments().Length == 2)
+            .MakeGenericMethod(elementType, resultType);
+    }
+
+    private static MethodInfo GetFirstOrDefaultMethod(Type resultType)
+    {
+        return typeof(Enumerable)
+            .GetMethods(BindingFlags.Static | BindingFlags.Public)
+            .Where(m => m.Name == nameof(Enumerable.FirstOrDefault) && m.GetParameters().Length == 1)
+            .First(m => m.GetParameters()[0].ParameterType.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+            .MakeGenericMethod(resultType);
     }
 
     private static Expression BuildConditionalExpression(List<Expression> memberAccess, int index)

--- a/src/Mpt.Rql/Core/PathInfoBuilder.cs
+++ b/src/Mpt.Rql/Core/PathInfoBuilder.cs
@@ -133,7 +133,7 @@ internal abstract class PathInfoBuilder(IMetadataProvider metadataProvider, IBui
         return new MemberPathInfo(innerPropertyInfo, finalExpr);
     }
 
-    private static Expression WrapWithCollectionNullCheck(
+    private static ConditionalExpression WrapWithCollectionNullCheck(
         Expression collectionExpression,
         Expression valueExpression,
         List<Expression>? priorMemberAccess)

--- a/src/Mpt.Rql/RqlExtensions.cs
+++ b/src/Mpt.Rql/RqlExtensions.cs
@@ -17,6 +17,7 @@ using Mpt.Rql.Services.Filtering.Builders;
 using Mpt.Rql.Services.Filtering.Operators;
 using Mpt.Rql.Services.Mapping;
 using Mpt.Rql.Services.Ordering;
+using Mpt.Rql.Services.Ordering.Functions;
 using Mpt.Rql.Services.Projection;
 using Mpt.Rql.Settings;
 using System.Reflection;
@@ -61,6 +62,8 @@ public static class RqlExtensions
         services.AddScoped(typeof(IOrderingService<>), typeof(OrderingService<>));
         services.AddScoped<IOrderingPathInfoBuilder, OrderingPathInfoBuilder>();
         services.AddScoped(typeof(IOrderingGraphBuilder<>), typeof(OrderingGraphBuilder<>));
+        services.AddScoped<IOrderingFunction, OrderByOrderingFunction>();
+        services.AddScoped<IOrderingFunctionProvider, OrderingFunctionProvider>();
 
         services.AddScoped(typeof(IProjectionService<>), typeof(ProjectionService<>));
         services.AddScoped(typeof(IProjectionGraphBuilder<>), typeof(ProjectionGraphBuilder<>));

--- a/src/Mpt.Rql/Services/Ordering/Functions/OrderByOrderingFunction.cs
+++ b/src/Mpt.Rql/Services/Ordering/Functions/OrderByOrderingFunction.cs
@@ -1,0 +1,116 @@
+using Mpt.Rql.Abstractions.Result;
+using Mpt.Rql.Core;
+using System.Globalization;
+using System.Linq.Expressions;
+
+namespace Mpt.Rql.Services.Ordering.Functions;
+
+/// <summary>
+/// Built-in ordering function that sorts by the value of a specific element in a key/value
+/// collection, identified by a filter property and value.
+/// </summary>
+/// <remarks>
+/// <para><b>Syntax:</b> <c>+orderby(collectionProperty,filterPropertyName,filterValue,resultPropertyName)</c></para>
+/// <para><b>Example:</b> <c>+orderby(parameters,name,priority,value)</c></para>
+/// <para>
+/// This translates to:
+/// <code>
+/// x.Parameters
+///   .Where(p => p.Name == "priority")
+///   .Select(p => p.Value)
+///   .FirstOrDefault()
+/// </code>
+/// When no element matches the filter the sort key is <c>null</c> (or <c>null</c> for value types),
+/// which sorts before any non-null value in ascending order.
+/// </para>
+/// </remarks>
+internal class OrderByOrderingFunction : IOrderingFunction
+{
+    private readonly IOrderingPathInfoBuilder _pathBuilder;
+
+    public OrderByOrderingFunction(IOrderingPathInfoBuilder pathBuilder)
+    {
+        _pathBuilder = pathBuilder;
+    }
+
+    public string FunctionName => "orderby";
+
+    public Result<Expression> Build(Expression root, IReadOnlyList<string> arguments)
+    {
+        if (arguments.Count != 4)
+            return Error.Validation(
+                $"'orderby' requires exactly 4 arguments: " +
+                $"(collectionProperty, filterPropertyName, filterValue, resultPropertyName). " +
+                $"Got {arguments.Count}.");
+
+        var collectionPropPath = arguments[0];
+        var filterPropName = arguments[1];
+        var filterValue = arguments[2];
+        var resultPropName = arguments[3];
+
+        // Resolve the collection property on the root entity
+        var collectionResult = _pathBuilder.Build(root, collectionPropPath);
+        if (collectionResult.IsError)
+            return collectionResult.Errors;
+
+        var collectionPropInfo = collectionResult.Value!.PropertyInfo;
+        if (collectionPropInfo.Type != RqlPropertyType.Collection)
+            return Error.Validation($"'{collectionPropPath}' is not a collection property.");
+
+        var collectionExpression = collectionResult.Value.Expression;
+        var elementType = collectionPropInfo.ElementType!;
+        var innerParam = Expression.Parameter(elementType);
+
+        // Resolve and validate the filter property on the collection element type
+        var filterPropResult = _pathBuilder.Build(innerParam, filterPropName);
+        if (filterPropResult.IsError)
+            return filterPropResult.Errors;
+
+        var filterExpression = filterPropResult.Value!.Expression;
+
+        // Convert the filter value string to the actual property type
+        Expression filterConstantExpr;
+        try
+        {
+            var targetType = Nullable.GetUnderlyingType(filterExpression.Type) ?? filterExpression.Type;
+            var converted = Convert.ChangeType(filterValue, targetType, CultureInfo.InvariantCulture);
+            filterConstantExpr = Expression.Constant(converted, filterExpression.Type);
+        }
+        catch
+        {
+            return Error.Validation(
+                $"Cannot convert filter value '{filterValue}' to type '{filterExpression.Type.Name}'.");
+        }
+
+        // Build predicate: element => element.FilterProperty == filterValue
+        var filterPredicate = Expression.Lambda(
+            Expression.Equal(filterExpression, filterConstantExpr),
+            innerParam);
+
+        // Resolve and validate the result property on the collection element type
+        var resultPropResult = _pathBuilder.Build(innerParam, resultPropName);
+        if (resultPropResult.IsError)
+            return resultPropResult.Errors;
+
+        var resultExpression = resultPropResult.Value!.Expression;
+
+        // For value types, use a nullable selector so an empty/no-match result returns null
+        // rather than default(T), giving correct null ordering semantics
+        var selectorResultType = resultExpression.Type;
+        Expression selectorBody = resultExpression;
+        if (selectorResultType.IsValueType && Nullable.GetUnderlyingType(selectorResultType) == null)
+        {
+            selectorResultType = typeof(Nullable<>).MakeGenericType(selectorResultType);
+            selectorBody = Expression.Convert(resultExpression, selectorResultType);
+        }
+
+        // Build: collection.Where(predicate).Select(selector).FirstOrDefault()
+        var methods = (IWhereSelectMethods)Activator.CreateInstance(
+            typeof(WhereSelectMethods<,>).MakeGenericType(elementType, selectorResultType))!;
+
+        var selectLambda = Expression.Lambda(selectorBody, innerParam);
+        var whereCall = Expression.Call(null, methods.GetWhere(), collectionExpression, filterPredicate);
+        var selectCall = Expression.Call(null, methods.GetSelect(), whereCall, selectLambda);
+        return Expression.Call(null, methods.GetFirstOrDefault(), selectCall);
+    }
+}

--- a/src/Mpt.Rql/Services/Ordering/Functions/WhereSelectMethods.cs
+++ b/src/Mpt.Rql/Services/Ordering/Functions/WhereSelectMethods.cs
@@ -1,0 +1,59 @@
+using System.Reflection;
+
+namespace Mpt.Rql.Services.Ordering.Functions;
+
+/// <summary>
+/// Provides closed-generic <see cref="MethodInfo"/> references for
+/// <c>Enumerable.Where</c>, <c>Enumerable.Select</c>, and <c>Enumerable.FirstOrDefault</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The methods are obtained through type-safe delegate capture rather than reflection
+/// scanning (e.g. <c>typeof(Enumerable).GetMethods().Where(...)</c>). Assigning a method
+/// group to a typed delegate resolves overload selection at compile time; reading
+/// <c>.Method</c> from the resulting delegate yields the exact closed-generic
+/// <see cref="MethodInfo"/> needed to build <c>Expression.Call</c> nodes — without any
+/// fragile name-based or signature-based lookup.
+/// </para>
+/// <para>
+/// This follows the same pattern as
+/// <see cref="Mpt.Rql.Services.Filtering.Operators.Collection.Implementation.CollectionFunctions{T}"/>.
+/// </para>
+/// <para>
+/// The concrete type is instantiated at runtime via
+/// <c>Activator.CreateInstance(typeof(WhereSelectMethods&lt;,&gt;).MakeGenericType(elementType, resultType))</c>
+/// once the element and result types are known from the parsed RQL arguments.
+/// </para>
+/// </remarks>
+internal interface IWhereSelectMethods
+{
+    /// <summary>Returns <c>MethodInfo</c> for <c>Enumerable.Where&lt;TElement&gt;</c>.</summary>
+    MethodInfo GetWhere();
+
+    /// <summary>Returns <c>MethodInfo</c> for <c>Enumerable.Select&lt;TElement, TResult&gt;</c>.</summary>
+    MethodInfo GetSelect();
+
+    /// <summary>Returns <c>MethodInfo</c> for <c>Enumerable.FirstOrDefault&lt;TResult&gt;</c>.</summary>
+    MethodInfo GetFirstOrDefault();
+}
+
+internal class WhereSelectMethods<TElement, TResult> : IWhereSelectMethods
+{
+    public MethodInfo GetWhere()
+    {
+        Func<IEnumerable<TElement>, Func<TElement, bool>, IEnumerable<TElement>> func = Enumerable.Where;
+        return func.Method;
+    }
+
+    public MethodInfo GetSelect()
+    {
+        Func<IEnumerable<TElement>, Func<TElement, TResult>, IEnumerable<TResult>> func = Enumerable.Select;
+        return func.Method;
+    }
+
+    public MethodInfo GetFirstOrDefault()
+    {
+        Func<IEnumerable<TResult>, TResult?> func = Enumerable.FirstOrDefault;
+        return func.Method;
+    }
+}

--- a/src/Mpt.Rql/Services/Ordering/IOrderingFunction.cs
+++ b/src/Mpt.Rql/Services/Ordering/IOrderingFunction.cs
@@ -1,0 +1,34 @@
+using Mpt.Rql.Core;
+using System.Linq.Expressions;
+
+#pragma warning disable IDE0130
+namespace Mpt.Rql;
+
+/// <summary>
+/// Defines a custom ordering function usable in RQL sort expressions.
+/// </summary>
+/// <remarks>
+/// Implement this interface and register it with the DI container as
+/// <see cref="IOrderingFunction"/> to add a custom function to the sort parser.
+/// <para>
+/// Functions are referenced in RQL order expressions as:
+/// <c>+functionName(arg1,arg2,...)</c>
+/// </para>
+/// <para>
+/// The built-in <see cref="Mpt.Rql.Services.Ordering.Functions.OrderByOrderingFunction"/> uses this contract:
+/// <c>+orderby(collectionProperty,filterPropertyName,filterValue,resultPropertyName)</c>
+/// </para>
+/// </remarks>
+public interface IOrderingFunction
+{
+    /// <summary>The function name as it appears in the sort expression (case-insensitive).</summary>
+    string FunctionName { get; }
+
+    /// <summary>
+    /// Builds a LINQ expression that produces the sort key value for a given root entity.
+    /// </summary>
+    /// <param name="root">Parameter expression representing the root entity.</param>
+    /// <param name="arguments">Ordered list of string arguments from the sort expression.</param>
+    /// <returns>A <see cref="Result{T}"/> containing the key expression or validation errors.</returns>
+    Result<Expression> Build(Expression root, IReadOnlyList<string> arguments);
+}

--- a/src/Mpt.Rql/Services/Ordering/IOrderingFunctionProvider.cs
+++ b/src/Mpt.Rql/Services/Ordering/IOrderingFunctionProvider.cs
@@ -1,0 +1,17 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Mpt.Rql.Services.Ordering;
+
+/// <summary>
+/// Resolves <see cref="IOrderingFunction"/> implementations by their declared function name.
+/// </summary>
+internal interface IOrderingFunctionProvider
+{
+    /// <summary>
+    /// Looks up a registered ordering function by name (case-insensitive).
+    /// </summary>
+    /// <param name="functionName">The name as it appears in the RQL sort expression.</param>
+    /// <param name="function">The resolved function, or <c>null</c> when not found.</param>
+    /// <returns><c>true</c> if a function with the given name is registered; otherwise <c>false</c>.</returns>
+    bool TryGet(string functionName, [NotNullWhen(true)] out IOrderingFunction? function);
+}

--- a/src/Mpt.Rql/Services/Ordering/OrderingFunctionProvider.cs
+++ b/src/Mpt.Rql/Services/Ordering/OrderingFunctionProvider.cs
@@ -1,0 +1,26 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Mpt.Rql.Services.Ordering;
+
+/// <summary>
+/// Default <see cref="IOrderingFunctionProvider"/> that resolves functions from all
+/// <see cref="IOrderingFunction"/> registrations in the DI container.
+/// </summary>
+/// <remarks>
+/// Functions are keyed by <see cref="IOrderingFunction.FunctionName"/> and looked up
+/// case-insensitively, so <c>OrderBy</c> and <c>orderby</c> resolve to the same function.
+/// </remarks>
+internal class OrderingFunctionProvider : IOrderingFunctionProvider
+{
+    private readonly Dictionary<string, IOrderingFunction> _functions;
+
+    /// <param name="functions">All <see cref="IOrderingFunction"/> instances registered with DI.</param>
+    public OrderingFunctionProvider(IEnumerable<IOrderingFunction> functions)
+    {
+        _functions = functions.ToDictionary(f => f.FunctionName, StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <inheritdoc/>
+    public bool TryGet(string functionName, [NotNullWhen(true)] out IOrderingFunction? function)
+        => _functions.TryGetValue(functionName, out function);
+}

--- a/src/Mpt.Rql/Services/Ordering/OrderingService.cs
+++ b/src/Mpt.Rql/Services/Ordering/OrderingService.cs
@@ -53,7 +53,7 @@ internal sealed class OrderingService<TView> : RqlService, IOrderingService<TVie
                 .Where(item => item is RqlConstant || item is RqlGenericGroup)
                 .ToList();
 
-        if (!orderItems.Any())
+        if (orderItems.Count == 0)
         {
             _context.AddError(Error.Validation("No valid ordering properties were detected", MakeErrorCode("no_props")));
             return;
@@ -64,55 +64,11 @@ internal sealed class OrderingService<TView> : RqlService, IOrderingService<TVie
 
         foreach (var item in orderItems)
         {
-            Expression? keyExpression = null;
-            bool isAsc;
-
-            if (item is RqlConstant constant)
-            {
-                var (path, constIsAsc) = StringHelper.ExtractSign(constant.Value);
-                isAsc = constIsAsc;
-
-                var member = _pathBuilder.Build(param, path.ToString());
-                if (member.IsError)
-                {
-                    _context.AddErrors(member.Errors);
-                    continue;
-                }
-
-                keyExpression = member.Value!.Expression;
-            }
-            else if (item is RqlGenericGroup group)
-            {
-                var (funcNameMemory, funcIsAsc) = StringHelper.ExtractSign(group.Name);
-                isAsc = funcIsAsc;
-                var funcName = funcNameMemory.ToString();
-
-                if (!_functionProvider.TryGet(funcName, out var function))
-                {
-                    _context.AddError(Error.Validation(
-                        $"Unknown ordering function '{funcName}'.",
-                        MakeErrorCode("unknown_func")));
-                    continue;
-                }
-
-                var arguments = (group.Items ?? [])
-                    .OfType<RqlConstant>()
-                    .Select(c => c.Value)
-                    .ToArray();
-
-                var funcResult = function.Build(param, arguments);
-                if (funcResult.IsError)
-                {
-                    _context.AddErrors(funcResult.Errors);
-                    continue;
-                }
-
-                keyExpression = funcResult.Value!;
-            }
-            else
-            {
+            var resolved = ResolveOrderItem(item, param);
+            if (resolved == null)
                 continue;
-            }
+
+            var (keyExpression, isAsc) = resolved.Value;
 
             var method = MakeOrderingMethod(keyExpression, isAsc, isFirst);
             var expression = Expression.Lambda(keyExpression, param);
@@ -120,6 +76,59 @@ internal sealed class OrderingService<TView> : RqlService, IOrderingService<TVie
             _context.AddTransformation(q => (IQueryable<TView>)method.Invoke(null, new object[] { q, expression })!);
             isFirst = false;
         }
+    }
+
+    private (Expression KeyExpression, bool IsAsc)? ResolveOrderItem(RqlExpression item, ParameterExpression param)
+    {
+        if (item is RqlConstant constant)
+            return ResolveConstantOrder(constant, param);
+
+        if (item is RqlGenericGroup group)
+            return ResolveFunctionOrder(group, param);
+
+        return null;
+    }
+
+    private (Expression KeyExpression, bool IsAsc)? ResolveConstantOrder(RqlConstant constant, ParameterExpression param)
+    {
+        var (path, isAsc) = StringHelper.ExtractSign(constant.Value);
+
+        var member = _pathBuilder.Build(param, path.ToString());
+        if (member.IsError)
+        {
+            _context.AddErrors(member.Errors);
+            return null;
+        }
+
+        return (member.Value!.Expression, isAsc);
+    }
+
+    private (Expression KeyExpression, bool IsAsc)? ResolveFunctionOrder(RqlGenericGroup group, ParameterExpression param)
+    {
+        var (funcNameMemory, isAsc) = StringHelper.ExtractSign(group.Name);
+        var funcName = funcNameMemory.ToString();
+
+        if (!_functionProvider.TryGet(funcName, out var function))
+        {
+            _context.AddError(Error.Validation(
+                $"Unknown ordering function '{funcName}'.",
+                MakeErrorCode("unknown_func")));
+            return null;
+        }
+
+        var arguments = (group.Items ?? [])
+            .OfType<RqlConstant>()
+            .Select(c => c.Value)
+            .ToArray();
+
+        var funcResult = function.Build(param, arguments);
+        if (funcResult.IsError)
+        {
+            _context.AddErrors(funcResult.Errors);
+            return null;
+        }
+
+        return (funcResult.Value!, isAsc);
     }
 
     private static MethodInfo MakeOrderingMethod(Expression member, bool isAsc, bool isFirst)

--- a/src/Mpt.Rql/Services/Ordering/OrderingService.cs
+++ b/src/Mpt.Rql/Services/Ordering/OrderingService.cs
@@ -1,5 +1,6 @@
 using Mpt.Rql.Abstractions;
 using Mpt.Rql.Abstractions.Argument;
+using Mpt.Rql.Abstractions.Group;
 using Mpt.Rql.Abstractions.Result;
 using Mpt.Rql.Core;
 using Mpt.Rql.Services.Context;
@@ -14,13 +15,20 @@ internal sealed class OrderingService<TView> : RqlService, IOrderingService<TVie
     private readonly IOrderingGraphBuilder<TView> _graphBuilder;
     private readonly IOrderingPathInfoBuilder _pathBuilder;
     private readonly IRqlParser _parser;
+    private readonly IOrderingFunctionProvider _functionProvider;
 
-    public OrderingService(IQueryContext<TView> context, IOrderingGraphBuilder<TView> graphBuilder, IRqlParser parser, IOrderingPathInfoBuilder pathBuilder) : base()
+    public OrderingService(
+        IQueryContext<TView> context,
+        IOrderingGraphBuilder<TView> graphBuilder,
+        IRqlParser parser,
+        IOrderingPathInfoBuilder pathBuilder,
+        IOrderingFunctionProvider functionProvider) : base()
     {
         _context = context;
         _graphBuilder = graphBuilder;
         _parser = parser;
         _pathBuilder = pathBuilder;
+        _functionProvider = functionProvider;
     }
 
     protected override string ErrorPrefix => "order";
@@ -34,8 +42,18 @@ internal sealed class OrderingService<TView> : RqlService, IOrderingService<TVie
 
         _graphBuilder.TraverseRqlExpression(_context.Graph, node);
 
-        var orderProperties = node.Items!.OfType<RqlConstant>().ToList();
-        if (!orderProperties.Any())
+        // When the entire ordering string is a single function call (e.g. +orderby(...)),
+        // the parser returns the RqlGenericGroup directly as the root node — its Name holds
+        // the function name (with sign prefix) and its Items hold the function arguments.
+        // For multi-item expressions (e.g. "+name,-id") the root is an RqlAnd whose Items
+        // are the individual sort terms. The guard below normalises both shapes.
+        var orderItems = node is RqlGenericGroup { Name.Length: > 0 }
+            ? [(RqlExpression)node]
+            : node.Items!
+                .Where(item => item is RqlConstant || item is RqlGenericGroup)
+                .ToList();
+
+        if (!orderItems.Any())
         {
             _context.AddError(Error.Validation("No valid ordering properties were detected", MakeErrorCode("no_props")));
             return;
@@ -44,19 +62,60 @@ internal sealed class OrderingService<TView> : RqlService, IOrderingService<TVie
         var isFirst = true;
         var param = Expression.Parameter(typeof(TView));
 
-        foreach (var property in orderProperties)
+        foreach (var item in orderItems)
         {
-            var (path, isAsc) = StringHelper.ExtractSign(property.Value);
-            var member = _pathBuilder.Build(param, path.ToString());
+            Expression? keyExpression = null;
+            bool isAsc;
 
-            if (member.IsError)
+            if (item is RqlConstant constant)
             {
-                _context.AddErrors(member.Errors);
+                var (path, constIsAsc) = StringHelper.ExtractSign(constant.Value);
+                isAsc = constIsAsc;
+
+                var member = _pathBuilder.Build(param, path.ToString());
+                if (member.IsError)
+                {
+                    _context.AddErrors(member.Errors);
+                    continue;
+                }
+
+                keyExpression = member.Value!.Expression;
+            }
+            else if (item is RqlGenericGroup group)
+            {
+                var (funcNameMemory, funcIsAsc) = StringHelper.ExtractSign(group.Name);
+                isAsc = funcIsAsc;
+                var funcName = funcNameMemory.ToString();
+
+                if (!_functionProvider.TryGet(funcName, out var function))
+                {
+                    _context.AddError(Error.Validation(
+                        $"Unknown ordering function '{funcName}'.",
+                        MakeErrorCode("unknown_func")));
+                    continue;
+                }
+
+                var arguments = (group.Items ?? [])
+                    .OfType<RqlConstant>()
+                    .Select(c => c.Value)
+                    .ToArray();
+
+                var funcResult = function.Build(param, arguments);
+                if (funcResult.IsError)
+                {
+                    _context.AddErrors(funcResult.Errors);
+                    continue;
+                }
+
+                keyExpression = funcResult.Value!;
+            }
+            else
+            {
                 continue;
             }
 
-            var method = MakeOrderingMethod(member.Value!.Expression, isAsc, isFirst);
-            var expression = Expression.Lambda(member.Value.Expression, param);
+            var method = MakeOrderingMethod(keyExpression, isAsc, isFirst);
+            var expression = Expression.Lambda(keyExpression, param);
 
             _context.AddTransformation(q => (IQueryable<TView>)method.Invoke(null, new object[] { q, expression })!);
             isFirst = false;

--- a/tests/Rql.Tests.Integration/Core/SupportCase.cs
+++ b/tests/Rql.Tests.Integration/Core/SupportCase.cs
@@ -1,0 +1,23 @@
+using Mpt.Rql;
+
+namespace Rql.Tests.Integration.Core;
+
+public class SupportCase
+{
+    [RqlProperty(IsCore = true)]
+    public int Id { get; set; }
+
+    [RqlProperty(IsCore = true)]
+    public string Title { get; set; } = null!;
+
+    public List<CaseParameter> Parameters { get; set; } = null!;
+}
+
+public class CaseParameter
+{
+    [RqlProperty(IsCore = true)]
+    public string Name { get; set; } = null!;
+
+    [RqlProperty(IsCore = true)]
+    public string? Value { get; set; }
+}

--- a/tests/Rql.Tests.Integration/Tests/Functionality/CollectionOrderTests.cs
+++ b/tests/Rql.Tests.Integration/Tests/Functionality/CollectionOrderTests.cs
@@ -1,0 +1,152 @@
+using Mpt.Rql;
+using Rql.Tests.Integration.Core;
+using Xunit;
+
+namespace Rql.Tests.Integration.Tests.Functionality;
+
+/// <summary>
+/// Tests for sorting by a scalar property of an inner collection element, e.g. sort(+orders.clientName).
+/// The first element of the collection is used as the sort key (Select + FirstOrDefault semantics).
+/// </summary>
+public class CollectionOrderTests
+{
+    private readonly IRqlQueryable<Product, Product> _rql;
+
+    public CollectionOrderTests()
+    {
+        _rql = RqlFactory.Make<Product>(services => { }, rql =>
+        {
+            rql.Settings.Select.Implicit = RqlSelectModes.Core | RqlSelectModes.Primitive | RqlSelectModes.Reference;
+            rql.Settings.Select.Explicit = RqlSelectModes.All;
+            rql.Settings.Select.MaxDepth = 10;
+        });
+    }
+
+    [Fact]
+    public void Ordering_ByCollectionInnerStringProperty_Ascending_NullsFirst()
+    {
+        // Products with no orders have a null first clientName and sort before those with orders
+        var testData = ProductRepository.Query();
+
+        var result = _rql.Transform(testData, new RqlRequest { Order = "+orders.clientName" });
+
+        Assert.True(result.IsSuccess);
+        var products = result.Query.ToList();
+        Assert.Equal(8, products.Count);
+
+        // Products 2,3,4,5,6,8 have empty Orders → null clientName → sort first (ascending)
+        var first6 = products.Take(6).ToList();
+        Assert.All(first6, p => Assert.Empty(p.Orders));
+
+        // Products 1 and 7 have orders with clientName "Michael" → come last
+        var last2 = products.Skip(6).ToList();
+        Assert.All(last2, p => Assert.Equal("Michael", p.Orders.First().ClientName));
+    }
+
+    [Fact]
+    public void Ordering_ByCollectionInnerStringProperty_Descending_NullsLast()
+    {
+        // Descending: non-null clientNames come first, null (empty orders) come last
+        var testData = ProductRepository.Query();
+
+        var result = _rql.Transform(testData, new RqlRequest { Order = "-orders.clientName" });
+
+        Assert.True(result.IsSuccess);
+        var products = result.Query.ToList();
+        Assert.Equal(8, products.Count);
+
+        // Products with orders come first when descending
+        var first2 = products.Take(2).ToList();
+        Assert.All(first2, p => Assert.Equal("Michael", p.Orders.First().ClientName));
+
+        // Products with empty orders (null clientName) come last
+        var last6 = products.Skip(2).ToList();
+        Assert.All(last6, p => Assert.Empty(p.Orders));
+    }
+
+    [Fact]
+    public void Ordering_ByCollectionInnerIntProperty_Ascending_NullsFirst()
+    {
+        // int property: value types are made nullable so empty-collection entries sort as null (first in asc)
+        var testData = ProductRepository.Query();
+
+        var result = _rql.Transform(testData, new RqlRequest { Order = "+orders.id" });
+
+        Assert.True(result.IsSuccess);
+        var products = result.Query.ToList();
+        Assert.Equal(8, products.Count);
+
+        // Products with empty orders (null first order id) sort before products with orders
+        var emptyOrderProducts = products.TakeWhile(p => !p.Orders.Any()).ToList();
+        Assert.NotEmpty(emptyOrderProducts);
+        Assert.All(emptyOrderProducts, p => Assert.Empty(p.Orders));
+
+        // At least one product with an order follows
+        Assert.Contains(products, p => p.Orders.Any());
+    }
+
+    [Fact]
+    public void Ordering_ByCollectionInnerProperty_DistinctValues_SortsCorrectly()
+    {
+        // Each product has exactly one tag with a unique value: "Tag1" through "Tag8"
+        // Ascending sort should yield Tag1, Tag2, ..., Tag8 order
+        var testData = ProductRepository.Query();
+
+        var result = _rql.Transform(testData, new RqlRequest { Order = "+tags.value" });
+
+        Assert.True(result.IsSuccess);
+        var products = result.Query.ToList();
+        Assert.Equal(8, products.Count);
+
+        // Tags are "Tag1".."Tag8"; string sort: Tag1 < Tag2 < ... < Tag8
+        var tagValues = products.Select(p => p.Tags.First().Value).ToList();
+        Assert.Equal(new[] { "Tag1", "Tag2", "Tag3", "Tag4", "Tag5", "Tag6", "Tag7", "Tag8" }, tagValues);
+    }
+
+    [Fact]
+    public void Ordering_ByCollectionInnerProperty_Descending_DistinctValues_SortsCorrectly()
+    {
+        var testData = ProductRepository.Query();
+
+        var result = _rql.Transform(testData, new RqlRequest { Order = "-tags.value" });
+
+        Assert.True(result.IsSuccess);
+        var products = result.Query.ToList();
+
+        var tagValues = products.Select(p => p.Tags.First().Value).ToList();
+        Assert.Equal(new[] { "Tag8", "Tag7", "Tag6", "Tag5", "Tag4", "Tag3", "Tag2", "Tag1" }, tagValues);
+    }
+
+    [Fact]
+    public void Ordering_ByCollectionInnerProperty_InvalidSubPath_ReturnsError()
+    {
+        var testData = ProductRepository.Query();
+
+        var result = _rql.Transform(testData, new RqlRequest { Order = "+orders.nonExistentField" });
+
+        Assert.False(result.IsSuccess);
+        Assert.NotEmpty(result.Errors);
+        Assert.Contains("Invalid property path.", result.Errors.First().Message);
+    }
+
+    [Fact]
+    public void Ordering_ByCollectionInnerProperty_CombinedWithScalarOrder_WorksCorrectly()
+    {
+        // Combine collection-inner sort with a regular scalar sort
+        var testData = ProductRepository.Query();
+
+        var result = _rql.Transform(testData, new RqlRequest { Order = "+orders.clientName,+id" });
+
+        Assert.True(result.IsSuccess);
+        var products = result.Query.ToList();
+        Assert.Equal(8, products.Count);
+
+        // Primary key: orders.clientName (null-first)
+        // Secondary key: id (ascending)
+        // Empty-orders products come first, ordered by id
+        var emptyOrdersProducts = products.TakeWhile(p => !p.Orders.Any()).ToList();
+        Assert.NotEmpty(emptyOrdersProducts);
+        var ids = emptyOrdersProducts.Select(p => p.Id).ToList();
+        Assert.Equal(ids.OrderBy(x => x).ToList(), ids); // secondary sort by id is ascending
+    }
+}

--- a/tests/Rql.Tests.Integration/Tests/Functionality/CollectionOrderTests.cs
+++ b/tests/Rql.Tests.Integration/Tests/Functionality/CollectionOrderTests.cs
@@ -10,6 +10,9 @@ namespace Rql.Tests.Integration.Tests.Functionality;
 /// </summary>
 public class CollectionOrderTests
 {
+    private static readonly string[] TagsAscending = ["Tag1", "Tag2", "Tag3", "Tag4", "Tag5", "Tag6", "Tag7", "Tag8"];
+    private static readonly string[] TagsDescending = ["Tag8", "Tag7", "Tag6", "Tag5", "Tag4", "Tag3", "Tag2", "Tag1"];
+
     private readonly IRqlQueryable<Product, Product> _rql;
 
     public CollectionOrderTests()
@@ -77,12 +80,12 @@ public class CollectionOrderTests
         Assert.Equal(8, products.Count);
 
         // Products with empty orders (null first order id) sort before products with orders
-        var emptyOrderProducts = products.TakeWhile(p => !p.Orders.Any()).ToList();
+        var emptyOrderProducts = products.TakeWhile(p => p.Orders.Count == 0).ToList();
         Assert.NotEmpty(emptyOrderProducts);
         Assert.All(emptyOrderProducts, p => Assert.Empty(p.Orders));
 
         // At least one product with an order follows
-        Assert.Contains(products, p => p.Orders.Any());
+        Assert.Contains(products, p => p.Orders.Count > 0);
     }
 
     [Fact]
@@ -100,7 +103,7 @@ public class CollectionOrderTests
 
         // Tags are "Tag1".."Tag8"; string sort: Tag1 < Tag2 < ... < Tag8
         var tagValues = products.Select(p => p.Tags.First().Value).ToList();
-        Assert.Equal(new[] { "Tag1", "Tag2", "Tag3", "Tag4", "Tag5", "Tag6", "Tag7", "Tag8" }, tagValues);
+        Assert.Equal(TagsAscending, tagValues);
     }
 
     [Fact]
@@ -114,7 +117,7 @@ public class CollectionOrderTests
         var products = result.Query.ToList();
 
         var tagValues = products.Select(p => p.Tags.First().Value).ToList();
-        Assert.Equal(new[] { "Tag8", "Tag7", "Tag6", "Tag5", "Tag4", "Tag3", "Tag2", "Tag1" }, tagValues);
+        Assert.Equal(TagsDescending, tagValues);
     }
 
     [Fact]
@@ -144,7 +147,7 @@ public class CollectionOrderTests
         // Primary key: orders.clientName (null-first)
         // Secondary key: id (ascending)
         // Empty-orders products come first, ordered by id
-        var emptyOrdersProducts = products.TakeWhile(p => !p.Orders.Any()).ToList();
+        var emptyOrdersProducts = products.TakeWhile(p => p.Orders.Count == 0).ToList();
         Assert.NotEmpty(emptyOrdersProducts);
         var ids = emptyOrdersProducts.Select(p => p.Id).ToList();
         Assert.Equal(ids.OrderBy(x => x).ToList(), ids); // secondary sort by id is ascending

--- a/tests/Rql.Tests.Integration/Tests/Functionality/OrderByOrderTests.cs
+++ b/tests/Rql.Tests.Integration/Tests/Functionality/OrderByOrderTests.cs
@@ -1,0 +1,313 @@
+using Mpt.Rql;
+using Rql.Tests.Integration.Core;
+using Xunit;
+
+namespace Rql.Tests.Integration.Tests.Functionality;
+
+/// <summary>
+/// Integration tests for the built-in <c>orderby()</c> ordering function.
+/// Syntax: <c>+orderby(collectionProperty,filterPropertyName,filterValue,resultPropertyName)</c>
+/// Finds the first element in the collection matching the filter and uses its property as the sort key.
+/// </summary>
+public class OrderByOrderTests
+{
+    private readonly IRqlQueryable<Product, Product> _rql;
+
+    public OrderByOrderTests()
+    {
+        _rql = RqlFactory.Make<Product>(services => { }, rql =>
+        {
+            // Transparent mapping skips the TStorage→TView projection step (same type, no mapping needed).
+            // This lets tests use minimal inline data without initialising unrelated navigation properties.
+            rql.Settings.Mapping.Transparent = true;
+            rql.Settings.Select.Implicit = RqlSelectModes.Core | RqlSelectModes.Primitive;
+            rql.Settings.Select.Explicit = RqlSelectModes.All;
+            rql.Settings.Select.MaxDepth = 10;
+        });
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Builds a dataset where products have distinct "Michael"-order ids so the exact sort
+    /// sequence can be verified, plus two null-key products.
+    /// <para>
+    /// Layout:
+    ///   Id=1 → Michael order id=30  (highest key)
+    ///   Id=2 → Michael order id=10  (lowest key)
+    ///   Id=3 → Michael order id=20  (middle key)
+    ///   Id=4 → Tony order only       (null key — no Michael match)
+    ///   Id=5 → no orders             (null key)
+    /// </para>
+    /// </summary>
+    private static IQueryable<Product> MakeOrderByData() => new List<Product>
+    {
+        new() { Id = 1, Name = "A", Category = "X", Price = 1, SellPrice = 1, ListDate = DateTime.Now,
+                Orders = [new ProductOrder { Id = 30, ClientName = "Michael" }], OrdersIds = [30], Tags = [] },
+        new() { Id = 2, Name = "B", Category = "X", Price = 1, SellPrice = 1, ListDate = DateTime.Now,
+                Orders = [new ProductOrder { Id = 10, ClientName = "Michael" }], OrdersIds = [10], Tags = [] },
+        new() { Id = 3, Name = "C", Category = "X", Price = 1, SellPrice = 1, ListDate = DateTime.Now,
+                Orders = [new ProductOrder { Id = 20, ClientName = "Michael" }], OrdersIds = [20], Tags = [] },
+        new() { Id = 4, Name = "D", Category = "X", Price = 1, SellPrice = 1, ListDate = DateTime.Now,
+                Orders = [new ProductOrder { Id = 99, ClientName = "Tony" }], OrdersIds = [99], Tags = [] },
+        new() { Id = 5, Name = "E", Category = "X", Price = 1, SellPrice = 1, ListDate = DateTime.Now,
+                Orders = [], OrdersIds = [], Tags = [] },
+    }.AsQueryable();
+
+    // ── Exact sort-order tests (custom data with distinct keys) ──────────────
+
+    [Fact]
+    public void OrderBy_IntResult_Ascending_ExactOrder()
+    {
+        // null keys first (products 4, 5), then ascending by matched order id: 10→id=2, 20→id=3, 30→id=1
+        var result = _rql.Transform(MakeOrderByData(), new RqlRequest
+        {
+            Order = "+orderby(orders,clientName,Michael,id)"
+        });
+
+        Assert.True(result.IsSuccess);
+        var ids = result.Query.Select(p => p.Id).ToList();
+        Assert.Equal([4, 5, 2, 3, 1], ids);
+    }
+
+    [Fact]
+    public void OrderBy_IntResult_Descending_ExactOrder()
+    {
+        // Descending: 30→id=1, 20→id=3, 10→id=2, then nulls (4, 5)
+        var result = _rql.Transform(MakeOrderByData(), new RqlRequest
+        {
+            Order = "-orderby(orders,clientName,Michael,id)"
+        });
+
+        Assert.True(result.IsSuccess);
+        var ids = result.Query.Select(p => p.Id).ToList();
+        Assert.Equal([1, 3, 2, 4, 5], ids);
+    }
+
+    [Fact]
+    public void OrderBy_NullKeys_SortBeforeNonNull_Ascending()
+    {
+        // Explicitly verify null keys come first in ascending sort
+        var result = _rql.Transform(MakeOrderByData(), new RqlRequest
+        {
+            Order = "+orderby(orders,clientName,Michael,id)"
+        });
+
+        Assert.True(result.IsSuccess);
+        var products = result.Query.ToList();
+
+        var nullKeyProducts = products.TakeWhile(p => !p.Orders.Any(o => o.ClientName == "Michael")).ToList();
+        Assert.Equal(2, nullKeyProducts.Count);
+
+        var nonNullKeyProducts = products.Skip(2).ToList();
+        Assert.All(nonNullKeyProducts, p => Assert.Contains(p.Orders, o => o.ClientName == "Michael"));
+    }
+
+    [Fact]
+    public void OrderBy_NullKeys_SortAfterNonNull_Descending()
+    {
+        var result = _rql.Transform(MakeOrderByData(), new RqlRequest
+        {
+            Order = "-orderby(orders,clientName,Michael,id)"
+        });
+
+        Assert.True(result.IsSuccess);
+        var products = result.Query.ToList();
+
+        var nonNullFirst = products.TakeWhile(p => p.Orders.Any(o => o.ClientName == "Michael")).ToList();
+        Assert.Equal(3, nonNullFirst.Count);
+
+        var nullLast = products.Skip(3).ToList();
+        Assert.All(nullLast, p => Assert.DoesNotContain(p.Orders, o => o.ClientName == "Michael"));
+    }
+
+    [Fact]
+    public void OrderBy_UsesFirstMatch_NotMinOrMax()
+    {
+        // Product 1 has two Michael orders: id=99 first, id=1 second.
+        // orderby must use the FIRST matching order (id=99), not the minimum (id=1).
+        var data = new List<Product>
+        {
+            new() { Id = 1, Name = "MultiMatch", Category = "X", Price = 1, SellPrice = 1, ListDate = DateTime.Now,
+                    Orders = [
+                        new ProductOrder { Id = 99, ClientName = "Michael" },   // first match
+                        new ProductOrder { Id = 1,  ClientName = "Michael" },   // should be ignored
+                    ],
+                    OrdersIds = [99, 1], Tags = [] },
+            new() { Id = 2, Name = "SingleMatch", Category = "X", Price = 1, SellPrice = 1, ListDate = DateTime.Now,
+                    Orders = [new ProductOrder { Id = 50, ClientName = "Michael" }],
+                    OrdersIds = [50], Tags = [] },
+        }.AsQueryable();
+
+        var result = _rql.Transform(data, new RqlRequest
+        {
+            Order = "+orderby(orders,clientName,Michael,id)"
+        });
+
+        Assert.True(result.IsSuccess);
+        var products = result.Query.ToList();
+
+        // Product 2 key=50, Product 1 key=99 (first match) → Product 2 comes first ascending
+        // If min was used, Product 1 (min id=1) would come first — this test catches that bug
+        Assert.Equal(2, products[0].Id);
+        Assert.Equal(1, products[1].Id);
+    }
+
+    [Fact]
+    public void OrderBy_EmptyCollection_TreatedAsNullKey_SortsFirst_Ascending()
+    {
+        var data = new List<Product>
+        {
+            new() { Id = 1, Name = "A", Category = "X", Price = 1, SellPrice = 1, ListDate = DateTime.Now,
+                    Orders = [new ProductOrder { Id = 5, ClientName = "Michael" }],
+                    OrdersIds = [5], Tags = [] },
+            new() { Id = 2, Name = "B", Category = "X", Price = 1, SellPrice = 1, ListDate = DateTime.Now,
+                    Orders = [], OrdersIds = [], Tags = [] },  // empty collection → null key
+        }.AsQueryable();
+
+        var result = _rql.Transform(data, new RqlRequest
+        {
+            Order = "+orderby(orders,clientName,Michael,id)"
+        });
+
+        Assert.True(result.IsSuccess);
+        var ids = result.Query.Select(p => p.Id).ToList();
+        Assert.Equal([2, 1], ids);  // empty-collection product sorts first
+    }
+
+    [Fact]
+    public void OrderBy_IntFilterValue_Ascending()
+    {
+        // Filter on an int property (orders.id), result is a string property
+        // Only Product 2 has an order with id=10 → non-null key, comes last ascending
+        var result = _rql.Transform(MakeOrderByData(), new RqlRequest
+        {
+            Order = "+orderby(orders,id,10,clientName)"
+        });
+
+        Assert.True(result.IsSuccess);
+        var products = result.Query.ToList();
+
+        Assert.Equal(2, products.Last().Id);
+        Assert.Equal("Michael", products.Last().Orders.First(o => o.Id == 10).ClientName);
+    }
+
+    [Fact]
+    public void OrderBy_StringResult_Ascending_AlphabeticOrder()
+    {
+        var data = new List<Product>
+        {
+            new() { Id = 1, Name = "A", Category = "X", Price = 1, SellPrice = 1, ListDate = DateTime.Now,
+                    Orders = [new ProductOrder { Id = 1, ClientName = "Zara" }], OrdersIds = [1], Tags = [] },
+            new() { Id = 2, Name = "B", Category = "X", Price = 1, SellPrice = 1, ListDate = DateTime.Now,
+                    Orders = [new ProductOrder { Id = 1, ClientName = "Alice" }], OrdersIds = [1], Tags = [] },
+            new() { Id = 3, Name = "C", Category = "X", Price = 1, SellPrice = 1, ListDate = DateTime.Now,
+                    Orders = [new ProductOrder { Id = 1, ClientName = "Mark" }], OrdersIds = [1], Tags = [] },
+        }.AsQueryable();
+
+        var result = _rql.Transform(data, new RqlRequest
+        {
+            Order = "+orderby(orders,id,1,clientName)"
+        });
+
+        Assert.True(result.IsSuccess);
+        var ids = result.Query.Select(p => p.Id).ToList();
+        // Alice(2) < Mark(3) < Zara(1)
+        Assert.Equal([2, 3, 1], ids);
+    }
+
+    [Fact]
+    public void OrderBy_CombinedWithScalarSort_TieBreaking()
+    {
+        // Products 4 and 5 both have null keys; secondary +id should order them 4, 5
+        var result = _rql.Transform(MakeOrderByData(), new RqlRequest
+        {
+            Order = "+orderby(orders,clientName,Michael,id),+id"
+        });
+
+        Assert.True(result.IsSuccess);
+        var products = result.Query.ToList();
+
+        // Null-key group comes first, ordered by id
+        var nullKeyIds = products.Take(2).Select(p => p.Id).ToList();
+        Assert.Equal([4, 5], nullKeyIds);
+
+        // Non-null group sorted by matched order id: 10→id=2, 20→id=3, 30→id=1
+        var nonNullIds = products.Skip(2).Select(p => p.Id).ToList();
+        Assert.Equal([2, 3, 1], nonNullIds);
+    }
+
+    // ── Error cases ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void OrderBy_UnknownFunction_ReturnsError()
+    {
+        var result = _rql.Transform(ProductRepository.Query(), new RqlRequest
+        {
+            Order = "+unknownFunc(orders,id,1,clientName)"
+        });
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains(result.Errors, e => e.Message.Contains("Unknown ordering function"));
+    }
+
+    [Fact]
+    public void OrderBy_WrongArgCount_ReturnsError()
+    {
+        var result = _rql.Transform(ProductRepository.Query(), new RqlRequest
+        {
+            Order = "+orderby(orders,clientName,Michael)"  // 3 args, needs 4
+        });
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains(result.Errors, e => e.Message.Contains("4 arguments"));
+    }
+
+    [Fact]
+    public void OrderBy_NonCollectionProperty_ReturnsError()
+    {
+        var result = _rql.Transform(ProductRepository.Query(), new RqlRequest
+        {
+            Order = "+orderby(name,anything,val,anything)"  // "name" is string, not a collection
+        });
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains(result.Errors, e => e.Message.Contains("not a collection property"));
+    }
+
+    [Fact]
+    public void OrderBy_InvalidFilterProperty_ReturnsError()
+    {
+        var result = _rql.Transform(ProductRepository.Query(), new RqlRequest
+        {
+            Order = "+orderby(orders,nonExistent,val,clientName)"
+        });
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains(result.Errors, e => e.Message.Contains("Invalid property path."));
+    }
+
+    [Fact]
+    public void OrderBy_InvalidResultProperty_ReturnsError()
+    {
+        var result = _rql.Transform(ProductRepository.Query(), new RqlRequest
+        {
+            Order = "+orderby(orders,clientName,Michael,nonExistent)"
+        });
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains(result.Errors, e => e.Message.Contains("Invalid property path."));
+    }
+
+    [Fact]
+    public void OrderBy_IncompatibleFilterValueType_ReturnsError()
+    {
+        var result = _rql.Transform(ProductRepository.Query(), new RqlRequest
+        {
+            Order = "+orderby(orders,id,not-a-number,clientName)"  // orders.id is int
+        });
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains(result.Errors, e => e.Message.Contains("Cannot convert"));
+    }
+}

--- a/tests/Rql.Tests.Integration/Tests/Functionality/OrderByParameterValueTests.cs
+++ b/tests/Rql.Tests.Integration/Tests/Functionality/OrderByParameterValueTests.cs
@@ -1,0 +1,240 @@
+using Mpt.Rql;
+using Rql.Tests.Integration.Core;
+using Xunit;
+
+namespace Rql.Tests.Integration.Tests.Functionality;
+
+/// <summary>
+/// Integration tests for <c>orderby()</c> with a <c>Name</c>/<c>Value</c> parameter collection —
+/// the primary real-world use case:
+///
+/// <code>
+///   +orderby(parameters, name, priority, value)
+/// </code>
+///
+/// Each <see cref="SupportCase"/> carries a list of <see cref="CaseParameter"/> entries.
+/// The sort key is the <c>Value</c> of the parameter whose <c>Name</c> equals the filter value.
+/// <para>
+/// <b>String ordering note:</b> Values are sorted lexicographically, not by semantic importance
+/// (e.g. "critical" &lt; "high" &lt; "low" &lt; "medium" alphabetically).
+/// When the sort key should reflect business priority, store a numeric rank alongside the label,
+/// or use a different field as the result property.
+/// </para>
+/// </summary>
+public class OrderByParameterValueTests
+{
+    private readonly IRqlQueryable<SupportCase, SupportCase> _rql;
+
+    public OrderByParameterValueTests()
+    {
+        _rql = RqlFactory.Make<SupportCase>(services => { }, rql =>
+        {
+            rql.Settings.Mapping.Transparent = true;
+            rql.Settings.Select.Implicit = RqlSelectModes.Core | RqlSelectModes.Primitive;
+            rql.Settings.Select.Explicit = RqlSelectModes.All;
+            rql.Settings.Select.MaxDepth = 5;
+        });
+    }
+
+    // ── Shared dataset ───────────────────────────────────────────────────────
+
+    /// <summary>
+    /// SupportCases with the following priority values (alphabetical rank in parentheses):
+    /// <list type="bullet">
+    ///   <item>Id=1 → priority = "critical"  (rank 1)</item>
+    ///   <item>Id=2 → priority = "high"      (rank 2) + extra "status" parameter</item>
+    ///   <item>Id=3 → priority = "low"       (rank 3)</item>
+    ///   <item>Id=4 → priority = "medium"    (rank 4)</item>
+    ///   <item>Id=5 → no "priority" param    (null key)</item>
+    ///   <item>Id=6 → empty parameters       (null key)</item>
+    /// </list>
+    /// </summary>
+    private static IQueryable<SupportCase> MakeData() => new List<SupportCase>
+    {
+        new() { Id = 1, Title = "A", Parameters = [
+            new CaseParameter { Name = "priority", Value = "critical" }
+        ]},
+        new() { Id = 2, Title = "B", Parameters = [
+            new CaseParameter { Name = "priority", Value = "high"     },
+            new CaseParameter { Name = "status",   Value = "open"     },  // extra param — ignored by filter
+        ]},
+        new() { Id = 3, Title = "C", Parameters = [
+            new CaseParameter { Name = "priority", Value = "low"      }
+        ]},
+        new() { Id = 4, Title = "D", Parameters = [
+            new CaseParameter { Name = "priority", Value = "medium"   }
+        ]},
+        new() { Id = 5, Title = "E", Parameters = [
+            new CaseParameter { Name = "status",   Value = "pending"  }  // no "priority" → null key
+        ]},
+        new() { Id = 6, Title = "F", Parameters = [] },  // empty list → null key
+    }.AsQueryable();
+
+    // ── Ascending ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void OrderBy_StringValue_Ascending_NullsFirst_ThenLexicographic()
+    {
+        // Null keys (5, 6) sort before non-null keys.
+        // Non-null keys are sorted lexicographically: "critical" < "high" < "low" < "medium"
+        var result = _rql.Transform(MakeData(), new RqlRequest
+        {
+            Order = "+orderby(parameters,name,priority,value)"
+        });
+
+        Assert.True(result.IsSuccess);
+        var ids = result.Query.Select(sc => sc.Id).ToList();
+        Assert.Equal([5, 6, 1, 2, 3, 4], ids);
+    }
+
+    [Fact]
+    public void OrderBy_StringValue_Ascending_NullKeysAreTrueNulls_NotEmptyString()
+    {
+        // FirstOrDefault on a non-matching Where returns null for strings (not "").
+        // This test makes explicit that the null-sentinel is real null, not an empty string.
+        var result = _rql.Transform(MakeData(), new RqlRequest
+        {
+            Order = "+orderby(parameters,name,priority,value)"
+        });
+
+        Assert.True(result.IsSuccess);
+        var products = result.Query.ToList();
+
+        // First two have no priority parameter — their sort key is null, not ""
+        Assert.Equal(5, products[0].Id);
+        Assert.Equal(6, products[1].Id);
+        Assert.All(products.Take(2), sc =>
+            Assert.DoesNotContain(sc.Parameters, p => p.Name == "priority"));
+    }
+
+    // ── Descending ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void OrderBy_StringValue_Descending_NullsLast_ThenReverseLexicographic()
+    {
+        // Non-null keys in reverse lex order: "medium" > "low" > "high" > "critical"
+        // Null keys come last.
+        var result = _rql.Transform(MakeData(), new RqlRequest
+        {
+            Order = "-orderby(parameters,name,priority,value)"
+        });
+
+        Assert.True(result.IsSuccess);
+        var ids = result.Query.Select(sc => sc.Id).ToList();
+        Assert.Equal([4, 3, 2, 1, 5, 6], ids);
+    }
+
+    // ── Extra parameters on the same entity ─────────────────────────────────
+
+    [Fact]
+    public void OrderBy_IgnoresParametersNotMatchingFilter()
+    {
+        // SupportCase 2 has both "priority"="high" and "status"="open".
+        // Only the priority value should influence the sort; "status" is ignored.
+        var result = _rql.Transform(MakeData(), new RqlRequest
+        {
+            Order = "+orderby(parameters,name,priority,value)"
+        });
+
+        Assert.True(result.IsSuccess);
+        var sc2 = result.Query.Single(sc => sc.Id == 2);
+        // Verify Id=2 lands in position 4 (after critical, not bumped by "status"="open")
+        var ids = result.Query.Select(sc => sc.Id).ToList();
+        Assert.Equal(3, ids.IndexOf(2));  // zero-based index 3 → fourth position after two nulls + "critical"
+    }
+
+    // ── Null value in matching parameter ────────────────────────────────────
+
+    [Fact]
+    public void OrderBy_ParameterExistsButValueIsNull_TreatedAsNullKey()
+    {
+        // A parameter with the right Name but a null Value should sort as null (first ascending).
+        var data = new List<SupportCase>
+        {
+            new() { Id = 1, Title = "A", Parameters = [new CaseParameter { Name = "priority", Value = "high" }] },
+            new() { Id = 2, Title = "B", Parameters = [new CaseParameter { Name = "priority", Value = null  }] },
+        }.AsQueryable();
+
+        var result = _rql.Transform(data, new RqlRequest
+        {
+            Order = "+orderby(parameters,name,priority,value)"
+        });
+
+        Assert.True(result.IsSuccess);
+        var ids = result.Query.Select(sc => sc.Id).ToList();
+        // Null value → null sort key → first ascending
+        Assert.Equal([2, 1], ids);
+    }
+
+    // ── String ordering is lexicographic, not semantic ───────────────────────
+
+    [Fact]
+    public void OrderBy_StringOrdering_IsLexicographic_NotNumeric()
+    {
+        // Demonstrates that string ordering is character-by-character.
+        // "10" < "9" lexicographically (because '1' < '9') even though 10 > 9 numerically.
+        var data = new List<SupportCase>
+        {
+            new() { Id = 1, Title = "A", Parameters = [new CaseParameter { Name = "rank", Value = "9"  }] },
+            new() { Id = 2, Title = "B", Parameters = [new CaseParameter { Name = "rank", Value = "10" }] },
+            new() { Id = 3, Title = "C", Parameters = [new CaseParameter { Name = "rank", Value = "2"  }] },
+        }.AsQueryable();
+
+        var result = _rql.Transform(data, new RqlRequest
+        {
+            Order = "+orderby(parameters,name,rank,value)"
+        });
+
+        Assert.True(result.IsSuccess);
+        var ids = result.Query.Select(sc => sc.Id).ToList();
+        // Lex order: "10" < "2" < "9"  →  ids = [2, 3, 1]
+        Assert.Equal([2, 3, 1], ids);
+    }
+
+    // ── Filter is case-sensitive ─────────────────────────────────────────────
+
+    [Fact]
+    public void OrderBy_FilterNameIsCaseSensitive()
+    {
+        // "Priority" (capital P) does not match filter value "priority" (lowercase).
+        var data = new List<SupportCase>
+        {
+            new() { Id = 1, Title = "A", Parameters = [new CaseParameter { Name = "priority", Value = "high" }] },
+            new() { Id = 2, Title = "B", Parameters = [new CaseParameter { Name = "Priority", Value = "low"  }] },
+        }.AsQueryable();
+
+        var result = _rql.Transform(data, new RqlRequest
+        {
+            Order = "+orderby(parameters,name,priority,value)"  // filter = "priority" (lowercase)
+        });
+
+        Assert.True(result.IsSuccess);
+        var ids = result.Query.Select(sc => sc.Id).ToList();
+        // Id=1 has lowercase "priority" → key="high" → comes last ascending
+        // Id=2 has "Priority" (capital P) → no match → null key → comes first
+        Assert.Equal([2, 1], ids);
+    }
+
+    // ── Combined with scalar sort for tie-breaking ───────────────────────────
+
+    [Fact]
+    public void OrderBy_CombinedWithScalarSort_BreaksTiesById()
+    {
+        // Cases 5 and 6 both have null priority keys.
+        // Secondary sort by -id (descending) should order them: 6, 5.
+        var result = _rql.Transform(MakeData(), new RqlRequest
+        {
+            Order = "+orderby(parameters,name,priority,value),-id"
+        });
+
+        Assert.True(result.IsSuccess);
+        var ids = result.Query.Select(sc => sc.Id).ToList();
+
+        // Null-key group first, ordered by id descending: 6, 5
+        Assert.Equal(6, ids[0]);
+        Assert.Equal(5, ids[1]);
+
+        // Non-null group sorted lexicographically ascending (primary key unchanged)
+        Assert.Equal([1, 2, 3, 4], ids.Skip(2).ToList());
+    }
+}

--- a/tests/Rql.Tests.Unit/Services/Models/Parameter.cs
+++ b/tests/Rql.Tests.Unit/Services/Models/Parameter.cs
@@ -1,0 +1,12 @@
+using Mpt.Rql;
+
+namespace Rql.Tests.Unit.Services.Models;
+
+internal class Parameter
+{
+    [RqlProperty(IsCore = true)]
+    public string Name { get; set; } = null!;
+
+    [RqlProperty(IsCore = true)]
+    public string? Value { get; set; }
+}

--- a/tests/Rql.Tests.Unit/Services/Models/SupportCase.cs
+++ b/tests/Rql.Tests.Unit/Services/Models/SupportCase.cs
@@ -1,0 +1,14 @@
+using Mpt.Rql;
+
+namespace Rql.Tests.Unit.Services.Models;
+
+internal class SupportCase
+{
+    [RqlProperty(IsCore = true)]
+    public int Id { get; set; }
+
+    [RqlProperty(IsCore = true)]
+    public string Title { get; set; } = null!;
+
+    public List<Parameter> Parameters { get; set; } = null!;
+}

--- a/tests/Rql.Tests.Unit/Services/Ordering/OrderByOrderingFunctionTests.cs
+++ b/tests/Rql.Tests.Unit/Services/Ordering/OrderByOrderingFunctionTests.cs
@@ -1,0 +1,179 @@
+using FluentAssertions;
+using Moq;
+using Mpt.Rql.Abstractions.Configuration;
+using Mpt.Rql.Core;
+using Mpt.Rql.Core.Metadata;
+using Mpt.Rql.Services.Context;
+using Mpt.Rql.Services.Ordering;
+using Mpt.Rql.Services.Ordering.Functions;
+using Mpt.Rql.Settings;
+using Rql.Tests.Unit.Services.Models;
+using System.Linq.Expressions;
+using Xunit;
+
+namespace Rql.Tests.Unit.Services.Ordering;
+
+public class OrderByOrderingFunctionTests
+{
+    private static OrderByOrderingFunction MakeFunction()
+    {
+        var actionValidator = new Mock<IActionValidator>();
+        actionValidator.Setup(a => a.Validate(It.IsAny<RqlPropertyInfo>(), It.IsAny<Mpt.Rql.RqlActions>())).Returns(true);
+
+        var settings = new RqlSettings();
+        var metadataProvider = new MetadataProvider(new PropertyNameProvider(), new MetadataFactory(new GlobalRqlSettings()));
+        var builderContext = new BuilderContext();
+        var pathBuilder = new OrderingPathInfoBuilder(actionValidator.Object, metadataProvider, builderContext, settings);
+
+        return new OrderByOrderingFunction(pathBuilder);
+    }
+
+    [Fact]
+    public void Build_ValidArgs_ReturnsStringExpression()
+    {
+        // orderby(items, name, First, name) → items.Where(i => i.Name=="First").Select(i => i.Name).FirstOrDefault()
+        var func = MakeFunction();
+        var param = Expression.Parameter(typeof(Product), "p");
+
+        var result = func.Build(param, ["items", "name", "First", "name"]);
+
+        result.IsError.Should().BeFalse();
+        result.Value!.Type.Should().Be(typeof(string));
+    }
+
+    [Fact]
+    public void Build_ValueTypeResult_ReturnsNullableExpression()
+    {
+        // orderby(items, name, First, id) → items.Where(i => i.Name=="First").Select(i => (int?)i.Id).FirstOrDefault()
+        var func = MakeFunction();
+        var param = Expression.Parameter(typeof(Product), "p");
+
+        var result = func.Build(param, ["items", "name", "First", "id"]);
+
+        result.IsError.Should().BeFalse();
+        result.Value!.Type.Should().Be(typeof(int?));
+    }
+
+    [Fact]
+    public void Build_MatchingElement_ReturnsCorrectValue()
+    {
+        var func = MakeFunction();
+        var param = Expression.Parameter(typeof(Product), "p");
+        var built = func.Build(param, ["items", "name", "Target", "id"]);
+        built.IsError.Should().BeFalse();
+
+        var body = Expression.Convert(built.Value!, typeof(object));
+        var lambda = Expression.Lambda<Func<Product, object>>(body, param).Compile();
+        var product = new Product
+        {
+            Items =
+            [
+                new Item { Id = 10, Name = "Other" },
+                new Item { Id = 42, Name = "Target" },
+                new Item { Id = 99, Name = "Target" }  // second match — should not be returned
+            ]
+        };
+
+        // Act
+        var value = lambda(product);
+
+        // Assert: first match
+        value.Should().Be(42);
+    }
+
+    [Fact]
+    public void Build_NoMatchingElement_ReturnsNull()
+    {
+        var func = MakeFunction();
+        var param = Expression.Parameter(typeof(Product), "p");
+        var built = func.Build(param, ["items", "name", "NoSuchName", "id"]);
+        built.IsError.Should().BeFalse();
+
+        var body = Expression.Convert(built.Value!, typeof(object));
+        var lambda = Expression.Lambda<Func<Product, object>>(body, param).Compile();
+        var product = new Product { Items = [new Item { Id = 1, Name = "Other" }] };
+
+        // Act
+        var value = lambda(product);
+
+        value.Should().BeNull();
+    }
+
+    [Fact]
+    public void Build_EmptyCollection_ReturnsNull()
+    {
+        var func = MakeFunction();
+        var param = Expression.Parameter(typeof(Product), "p");
+        var built = func.Build(param, ["items", "name", "Anything", "name"]);
+        built.IsError.Should().BeFalse();
+
+        var body = Expression.Convert(built.Value!, typeof(object));
+        var lambda = Expression.Lambda<Func<Product, object>>(body, param).Compile();
+        var product = new Product { Items = [] };
+
+        var value = lambda(product);
+
+        value.Should().BeNull();
+    }
+
+    [Fact]
+    public void Build_WrongArgCount_ReturnsError()
+    {
+        var func = MakeFunction();
+        var param = Expression.Parameter(typeof(Product), "p");
+
+        var result = func.Build(param, ["items", "name", "val"]);  // only 3 args
+
+        result.IsError.Should().BeTrue();
+        result.Errors[0].Message.Should().Contain("4 arguments");
+    }
+
+    [Fact]
+    public void Build_NonCollectionProperty_ReturnsError()
+    {
+        var func = MakeFunction();
+        var param = Expression.Parameter(typeof(Product), "p");
+
+        var result = func.Build(param, ["name", "anything", "val", "anything"]);  // name is string, not a collection
+
+        result.IsError.Should().BeTrue();
+        result.Errors[0].Message.Should().Contain("not a collection property");
+    }
+
+    [Fact]
+    public void Build_InvalidFilterProperty_ReturnsError()
+    {
+        var func = MakeFunction();
+        var param = Expression.Parameter(typeof(Product), "p");
+
+        var result = func.Build(param, ["items", "nonExistentProp", "val", "name"]);
+
+        result.IsError.Should().BeTrue();
+        result.Errors[0].Message.Should().Be("Invalid property path.");
+    }
+
+    [Fact]
+    public void Build_InvalidResultProperty_ReturnsError()
+    {
+        var func = MakeFunction();
+        var param = Expression.Parameter(typeof(Product), "p");
+
+        var result = func.Build(param, ["items", "name", "val", "nonExistentProp"]);
+
+        result.IsError.Should().BeTrue();
+        result.Errors[0].Message.Should().Be("Invalid property path.");
+    }
+
+    [Fact]
+    public void Build_FilterValueIncompatibleType_ReturnsError()
+    {
+        // id is int; "not-a-number" cannot be converted to int
+        var func = MakeFunction();
+        var param = Expression.Parameter(typeof(Product), "p");
+
+        var result = func.Build(param, ["items", "id", "not-a-number", "name"]);
+
+        result.IsError.Should().BeTrue();
+        result.Errors[0].Message.Should().Contain("Cannot convert");
+    }
+}

--- a/tests/Rql.Tests.Unit/Services/Ordering/OrderByOrderingFunction_ParameterValueTests.cs
+++ b/tests/Rql.Tests.Unit/Services/Ordering/OrderByOrderingFunction_ParameterValueTests.cs
@@ -1,0 +1,183 @@
+using FluentAssertions;
+using Moq;
+using Mpt.Rql.Abstractions.Configuration;
+using Mpt.Rql.Core;
+using Mpt.Rql.Core.Metadata;
+using Mpt.Rql.Services.Context;
+using Mpt.Rql.Services.Ordering;
+using Mpt.Rql.Services.Ordering.Functions;
+using Mpt.Rql.Settings;
+using Rql.Tests.Unit.Services.Models;
+using System.Linq.Expressions;
+using Xunit;
+
+namespace Rql.Tests.Unit.Services.Ordering;
+
+/// <summary>
+/// Component tests for <see cref="OrderByOrderingFunction"/> using a <c>Name</c>/<c>Value</c>
+/// parameter collection — the primary real-world use case:
+///
+/// <code>
+///   +orderby(parameters, name, priority, value)
+/// </code>
+///
+/// Finds the first Parameter whose Name == "priority" and uses its Value (a nullable string)
+/// as the sort key.
+/// </summary>
+public class OrderByOrderingFunction_ParameterValueTests
+{
+    private static OrderByOrderingFunction MakeFunction()
+    {
+        var actionValidator = new Mock<IActionValidator>();
+        actionValidator.Setup(a => a.Validate(It.IsAny<RqlPropertyInfo>(), It.IsAny<Mpt.Rql.RqlActions>())).Returns(true);
+
+        var settings = new RqlSettings();
+        var metadataProvider = new MetadataProvider(new PropertyNameProvider(), new MetadataFactory(new GlobalRqlSettings()));
+        var builderContext = new BuilderContext();
+        var pathBuilder = new OrderingPathInfoBuilder(actionValidator.Object, metadataProvider, builderContext, settings);
+
+        return new OrderByOrderingFunction(pathBuilder);
+    }
+
+    // ── Return type ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Build_StringValueResult_ReturnsStringExpression()
+    {
+        // Value is already a nullable string — no extra wrapping needed
+        var func = MakeFunction();
+        var param = Expression.Parameter(typeof(SupportCase), "sc");
+
+        var result = func.Build(param, ["parameters", "name", "priority", "value"]);
+
+        result.IsError.Should().BeFalse();
+        result.Value!.Type.Should().Be(typeof(string));
+    }
+
+    // ── Correct value extraction ─────────────────────────────────────────────
+
+    [Fact]
+    public void Build_MatchingParameter_ReturnsValue()
+    {
+        var func = MakeFunction();
+        var param = Expression.Parameter(typeof(SupportCase), "sc");
+        var built = func.Build(param, ["parameters", "name", "priority", "value"]);
+        built.IsError.Should().BeFalse();
+
+        var lambda = Expression.Lambda<Func<SupportCase, string?>>(built.Value!, param).Compile();
+        var sc = new SupportCase
+        {
+            Id = 1,
+            Title = "T",
+            Parameters =
+            [
+                new Parameter { Name = "status",   Value = "open"     },
+                new Parameter { Name = "priority",  Value = "critical" },  // match
+                new Parameter { Name = "category",  Value = "billing"  },
+            ]
+        };
+
+        lambda(sc).Should().Be("critical");
+    }
+
+    [Fact]
+    public void Build_UsesFirstMatch_WhenMultipleParametersShareSameName()
+    {
+        // If two parameters both have Name="priority", the first one wins
+        var func = MakeFunction();
+        var param = Expression.Parameter(typeof(SupportCase), "sc");
+        var built = func.Build(param, ["parameters", "name", "priority", "value"]);
+        built.IsError.Should().BeFalse();
+
+        var lambda = Expression.Lambda<Func<SupportCase, string?>>(built.Value!, param).Compile();
+        var sc = new SupportCase
+        {
+            Id = 1,
+            Title = "T",
+            Parameters =
+            [
+                new Parameter { Name = "priority", Value = "high"     },   // first → wins
+                new Parameter { Name = "priority", Value = "critical" },   // second → ignored
+            ]
+        };
+
+        lambda(sc).Should().Be("high");
+    }
+
+    [Fact]
+    public void Build_ParameterWithNullValue_ReturnsNull()
+    {
+        // The matching parameter exists but its Value is null
+        var func = MakeFunction();
+        var param = Expression.Parameter(typeof(SupportCase), "sc");
+        var built = func.Build(param, ["parameters", "name", "priority", "value"]);
+        built.IsError.Should().BeFalse();
+
+        var lambda = Expression.Lambda<Func<SupportCase, string?>>(built.Value!, param).Compile();
+        var sc = new SupportCase
+        {
+            Id = 1,
+            Title = "T",
+            Parameters = [new Parameter { Name = "priority", Value = null }]
+        };
+
+        lambda(sc).Should().BeNull();
+    }
+
+    // ── Null / empty collection ──────────────────────────────────────────────
+
+    [Fact]
+    public void Build_NoMatchingParameter_ReturnsNull()
+    {
+        var func = MakeFunction();
+        var param = Expression.Parameter(typeof(SupportCase), "sc");
+        var built = func.Build(param, ["parameters", "name", "priority", "value"]);
+        built.IsError.Should().BeFalse();
+
+        var lambda = Expression.Lambda<Func<SupportCase, string?>>(built.Value!, param).Compile();
+        var sc = new SupportCase
+        {
+            Id = 1,
+            Title = "T",
+            Parameters = [new Parameter { Name = "status", Value = "open" }]  // no "priority"
+        };
+
+        lambda(sc).Should().BeNull();
+    }
+
+    [Fact]
+    public void Build_EmptyParameterCollection_ReturnsNull()
+    {
+        var func = MakeFunction();
+        var param = Expression.Parameter(typeof(SupportCase), "sc");
+        var built = func.Build(param, ["parameters", "name", "priority", "value"]);
+        built.IsError.Should().BeFalse();
+
+        var lambda = Expression.Lambda<Func<SupportCase, string?>>(built.Value!, param).Compile();
+        var sc = new SupportCase { Id = 1, Title = "T", Parameters = [] };
+
+        lambda(sc).Should().BeNull();
+    }
+
+    // ── Filter is case-sensitive ─────────────────────────────────────────────
+
+    [Fact]
+    public void Build_FilterIsCaseSensitive_WrongCaseYieldsNull()
+    {
+        // The == operator in the generated expression is ordinal (default for strings in C#)
+        var func = MakeFunction();
+        var param = Expression.Parameter(typeof(SupportCase), "sc");
+        var built = func.Build(param, ["parameters", "name", "priority", "value"]);
+        built.IsError.Should().BeFalse();
+
+        var lambda = Expression.Lambda<Func<SupportCase, string?>>(built.Value!, param).Compile();
+        var sc = new SupportCase
+        {
+            Id = 1,
+            Title = "T",
+            Parameters = [new Parameter { Name = "Priority", Value = "high" }]  // capital P — no match
+        };
+
+        lambda(sc).Should().BeNull();
+    }
+}

--- a/tests/Rql.Tests.Unit/Services/PathInfoBuilderTests.cs
+++ b/tests/Rql.Tests.Unit/Services/PathInfoBuilderTests.cs
@@ -189,4 +189,133 @@ public class PathInfoBuilderTests
         result.Errors.Should().NotBeEmpty();
         result.Errors[0].Message.Should().Be("Invalid property path.");
     }
+
+    [Fact]
+    public void Build_Ordering_CollectionInnerStringProperty_ReturnsStringType()
+    {
+        // Arrange
+        var (_, ordering) = MakeBuilders(NavigationStrategy.Default, NavigationStrategy.Default);
+        var param = Expression.Parameter(typeof(Product), "p");
+
+        // Act
+        var result = ordering.Build(param, "items.name");
+
+        // Assert
+        result.IsError.Should().BeFalse();
+        result.Value!.Expression.Type.Should().Be(typeof(string));
+    }
+
+    [Fact]
+    public void Build_Ordering_CollectionInnerValueTypeProperty_ReturnsNullableType()
+    {
+        // Arrange: int property inside a collection should come back as int? so empty collections
+        // return null (rather than 0) and sort correctly
+        var (_, ordering) = MakeBuilders(NavigationStrategy.Default, NavigationStrategy.Default);
+        var param = Expression.Parameter(typeof(Product), "p");
+
+        // Act
+        var result = ordering.Build(param, "items.id");
+
+        // Assert
+        result.IsError.Should().BeFalse();
+        result.Value!.Expression.Type.Should().Be(typeof(int?));
+    }
+
+    [Fact]
+    public void Build_Ordering_CollectionInnerProperty_ReturnsFirstElementValue()
+    {
+        // Arrange
+        var (_, ordering) = MakeBuilders(NavigationStrategy.Default, NavigationStrategy.Default);
+        var param = Expression.Parameter(typeof(Product), "p");
+        var built = ordering.Build(param, "items.name");
+        built.IsError.Should().BeFalse();
+
+        var body = Expression.Convert(built.Value!.Expression, typeof(object));
+        var lambda = Expression.Lambda<Func<Product, object>>(body, param).Compile();
+        var product = new Product { Items = [new Item { Id = 1, Name = "First" }, new Item { Id = 2, Name = "Second" }] };
+
+        // Act
+        var value = lambda(product);
+
+        // Assert
+        value.Should().Be("First");
+    }
+
+    [Fact]
+    public void Build_Ordering_CollectionInnerProperty_EmptyCollection_ReturnsNull()
+    {
+        // Arrange
+        var (_, ordering) = MakeBuilders(NavigationStrategy.Default, NavigationStrategy.Default);
+        var param = Expression.Parameter(typeof(Product), "p");
+        var built = ordering.Build(param, "items.name");
+        built.IsError.Should().BeFalse();
+
+        var body = Expression.Convert(built.Value!.Expression, typeof(object));
+        var lambda = Expression.Lambda<Func<Product, object>>(body, param).Compile();
+        var product = new Product { Items = [] };
+
+        // Act
+        var value = lambda(product);
+
+        // Assert
+        value.Should().BeNull();
+    }
+
+    [Fact]
+    public void Build_Ordering_CollectionInnerProperty_SafeNavigationOn_NullCollection_ReturnsNull()
+    {
+        // Arrange
+        var (_, ordering) = MakeBuilders(NavigationStrategy.Default, NavigationStrategy.Safe);
+        var param = Expression.Parameter(typeof(Product), "p");
+        var built = ordering.Build(param, "items.name");
+        built.IsError.Should().BeFalse();
+
+        var body = Expression.Convert(built.Value!.Expression, typeof(object));
+        var lambda = Expression.Lambda<Func<Product, object>>(body, param).Compile();
+        var product = new Product { Items = null! };
+
+        // Act
+        var value = lambda(product);
+
+        // Assert
+        value.Should().BeNull();
+    }
+
+    [Fact]
+    public void Build_Ordering_CollectionInnerProperty_SafeNavigation_WithPreCollectionReference_NullReference_ReturnsNull()
+    {
+        // Arrange: path crosses a reference (coreCategory) then a collection (products) — exercises the
+        // priorMemberAccess non-empty branch of WrapWithCollectionNullCheck
+        var (_, ordering) = MakeBuilders(NavigationStrategy.Default, NavigationStrategy.Safe);
+        var param = Expression.Parameter(typeof(Product), "p");
+        var built = ordering.Build(param, "coreCategory.products.name");
+        built.IsError.Should().BeFalse();
+
+        var body = Expression.Convert(built.Value!.Expression, typeof(object));
+        var lambda = Expression.Lambda<Func<Product, object>>(body, param).Compile();
+
+        // CoreCategory is null — should not throw despite the chain
+        var product = new Product { Name = "test" };
+
+        // Act
+        var value = lambda(product);
+
+        // Assert
+        value.Should().BeNull();
+    }
+
+    [Fact]
+    public void Build_Ordering_CollectionInnerProperty_InvalidSubPath_ReturnsError()
+    {
+        // Arrange
+        var (_, ordering) = MakeBuilders(NavigationStrategy.Default, NavigationStrategy.Default);
+        var param = Expression.Parameter(typeof(Product), "p");
+
+        // Act
+        var result = ordering.Build(param, "items.nonExistent");
+
+        // Assert
+        result.IsError.Should().BeTrue();
+        result.Errors[0].Message.Should().Be("Invalid property path.");
+    }
 }


### PR DESCRIPTION
Adds support for sorting entities by a value extracted from a child collection, using a filter to identify the relevant element:

  +orderby(collectionProperty,filterProp,filterValue,resultProp)

For example, +orderby(parameters,name,priority,value) translates to:
  x.Parameters.Where(p => p.Name == "priority")
              .Select(p => p.Value)
              .FirstOrDefault()

Key changes:
- New IOrderingFunction / IOrderingFunctionProvider extension point so custom sort functions can be registered via DI
- OrderByOrderingFunction implements the built-in orderby() function; builds a Where().Select().FirstOrDefault() expression tree at runtime
- WhereSelectMethods<TElement,TResult> captures Enumerable method infos via type-safe delegate capture (no fragile reflection scanning)
- PathInfoBuilder extended to handle dot-notation paths into collections (e.g. orders.clientName pivots to Select().FirstOrDefault())
- OrderingService dispatches RqlGenericGroup nodes to the function provider; fixes single-function ordering string root-node edge case
- 627 tests (410 unit + 217 integration) covering all new paths