### PR TITLE
#MPT-20406 Introduce RqlCustomPropertyResolver for filtering

### DIFF
--- a/src/Mpt.Rql.Abstractions/Exception/RqlInvalidCustomResolverException.cs
+++ b/src/Mpt.Rql.Abstractions/Exception/RqlInvalidCustomResolverException.cs
@@ -1,0 +1,9 @@
+namespace Mpt.Rql.Abstractions.Exception;
+
+public class RqlInvalidCustomResolverException : System.Exception
+{
+    public RqlInvalidCustomResolverException(string message)
+        : base(message)
+    {
+    }
+}

--- a/src/Mpt.Rql.Abstractions/IRqlCustomPropertyResolver.cs
+++ b/src/Mpt.Rql.Abstractions/IRqlCustomPropertyResolver.cs
@@ -3,24 +3,19 @@ using System.Linq.Expressions;
 namespace Mpt.Rql.Abstractions;
 
 /// <summary>
-/// Resolves property access on types that don't have standard CLR properties.
-/// When one or more <see cref="IRqlCustomPropertyResolver"/> implementations are registered,
-/// <c>PathInfoBuilder</c> tries each in order as a fallback when CLR reflection fails to find a property.
-/// Each resolver decides whether it handles the given parent expression and property name.
+/// Translates RQL sub-paths that have no CLR counterpart (e.g. keys of a dynamic JSON bag)
+/// into query expressions. Wired per-property via <c>[RqlProperty(CustomResolver = ...)]</c>.
 /// </summary>
 public interface IRqlCustomPropertyResolver
 {
     /// <summary>
-    /// Attempts to resolve a property name on the given parent expression.
+    /// Translates <paramref name="propertyPath"/> (single key or dotted for nested access)
+    /// anchored at <paramref name="parentExpression"/> into a leaf expression. Returning
+    /// <c>false</c> surfaces the standard "invalid property path" error.
     /// </summary>
-    /// <param name="parentExpression">The expression representing the parent (e.g. <c>e.Attributes.Navision</c>).</param>
-    /// <param name="propertyName">The property name to resolve (e.g. <c>ipCaseNo</c>).</param>
-    /// <param name="resolvedExpression">The resulting expression (e.g. a <c>JSON_VALUE</c> call).</param>
-    /// <param name="propertyInfo">A synthetic property descriptor defining allowed operators and actions.</param>
-    /// <returns><c>true</c> if the property was resolved; <c>false</c> to try the next resolver or fall through to the default error.</returns>
     bool TryResolve(
         Expression parentExpression,
-        string propertyName,
+        string propertyPath,
         out Expression resolvedExpression,
         out IRqlPropertyInfo propertyInfo);
 }

--- a/src/Mpt.Rql.Abstractions/IRqlCustomPropertyResolver.cs
+++ b/src/Mpt.Rql.Abstractions/IRqlCustomPropertyResolver.cs
@@ -1,0 +1,26 @@
+using System.Linq.Expressions;
+
+namespace Mpt.Rql.Abstractions;
+
+/// <summary>
+/// Resolves property access on types that don't have standard CLR properties.
+/// When one or more <see cref="IRqlCustomPropertyResolver"/> implementations are registered,
+/// <c>PathInfoBuilder</c> tries each in order as a fallback when CLR reflection fails to find a property.
+/// Each resolver decides whether it handles the given parent expression and property name.
+/// </summary>
+public interface IRqlCustomPropertyResolver
+{
+    /// <summary>
+    /// Attempts to resolve a property name on the given parent expression.
+    /// </summary>
+    /// <param name="parentExpression">The expression representing the parent (e.g. <c>e.Attributes.Navision</c>).</param>
+    /// <param name="propertyName">The property name to resolve (e.g. <c>ipCaseNo</c>).</param>
+    /// <param name="resolvedExpression">The resulting expression (e.g. a <c>JSON_VALUE</c> call).</param>
+    /// <param name="propertyInfo">A synthetic property descriptor defining allowed operators and actions.</param>
+    /// <returns><c>true</c> if the property was resolved; <c>false</c> to try the next resolver or fall through to the default error.</returns>
+    bool TryResolve(
+        Expression parentExpression,
+        string propertyName,
+        out Expression resolvedExpression,
+        out IRqlPropertyInfo propertyInfo);
+}

--- a/src/Mpt.Rql.Abstractions/RqlPropertyAttribute.cs
+++ b/src/Mpt.Rql.Abstractions/RqlPropertyAttribute.cs
@@ -1,3 +1,4 @@
+using Mpt.Rql.Abstractions;
 using Mpt.Rql.Abstractions.Exception;
 
 #pragma warning disable IDE0130
@@ -119,7 +120,7 @@ public class RqlPropertyAttribute : Attribute
 
     /// <summary>
     /// Type used to translate RQL sub-paths under this property — e.g. keys of a dynamic
-    /// <see cref="System.Text.Json.JsonElement"/> bag. Must implement
+    /// bag whose children aren't visible to CLR reflection. Must implement
     /// <see cref="IRqlCustomPropertyResolver"/> and be registered in DI.
     /// </summary>
     /// <exception cref="RqlInvalidCustomResolverException">Thrown when provided type does not implement <see cref="IRqlCustomPropertyResolver"/>.</exception>

--- a/src/Mpt.Rql.Abstractions/RqlPropertyAttribute.cs
+++ b/src/Mpt.Rql.Abstractions/RqlPropertyAttribute.cs
@@ -117,4 +117,11 @@ public class RqlPropertyAttribute : Attribute
     /// <exception cref="RqlInvalidActionStrategyException">Thrown when provided type does not implement <see cref="IActionStrategy"</exception>
     public Type? ActionStrategy { get; set; }
 
+    /// <summary>
+    /// Type used to translate RQL sub-paths under this property — e.g. keys of a dynamic
+    /// <see cref="System.Text.Json.JsonElement"/> bag. Must implement
+    /// <see cref="IRqlCustomPropertyResolver"/> and be registered in DI.
+    /// </summary>
+    /// <exception cref="RqlInvalidCustomResolverException">Thrown when provided type does not implement <see cref="IRqlCustomPropertyResolver"/>.</exception>
+    public Type? CustomResolver { get; set; }
 }

--- a/src/Mpt.Rql/Core/Metadata/MetadataFactory.cs
+++ b/src/Mpt.Rql/Core/Metadata/MetadataFactory.cs
@@ -1,3 +1,4 @@
+using Mpt.Rql.Abstractions;
 using Mpt.Rql.Abstractions.Configuration;
 using Mpt.Rql.Abstractions.Exception;
 using System.Collections;
@@ -42,6 +43,17 @@ internal class MetadataFactory : IMetadataFactory
                         $"does not implement {typeof(IActionStrategy).FullName}");
 
                 propertyInfo.ActionStrategy = attribute.ActionStrategy;
+            }
+
+            if (attribute.CustomResolver != null)
+            {
+                if (!typeof(IRqlCustomPropertyResolver).IsAssignableFrom(attribute.CustomResolver))
+                    throw new RqlInvalidCustomResolverException(
+                        $"Type {attribute.CustomResolver.FullName} defined as custom resolver for property " +
+                        $"({property.DeclaringType!.FullName}).{property.Name} " +
+                        $"does not implement {typeof(IRqlCustomPropertyResolver).FullName}");
+
+                propertyInfo.CustomResolver = attribute.CustomResolver;
             }
 
             if (attribute.ActionsSet)

--- a/src/Mpt.Rql/Core/PathInfoBuilder.cs
+++ b/src/Mpt.Rql/Core/PathInfoBuilder.cs
@@ -36,74 +36,90 @@ internal abstract class PathInfoBuilder(IMetadataProvider metadataProvider, IBui
 
     public Result<MemberPathInfo> Build(Expression root, string path)
     {
-        var nameSegments = path.Split('.');
-        var safeNavigation = UseSafeNavigation();
+        var segments = path.Split('.');
+        var memberAccess = new List<Expression>(segments.Length);
 
-        List<Expression>? memberAccess = null;
-        if (safeNavigation)
-            memberAccess = new List<Expression>(nameSegments.Length);
-
-        var currentType = root.Type;
-        RqlPropertyInfo? propInfo = null;
-        var pathExpression = root;
+        var state = PathWalkState.Initial(root);
         var currentPathLength = 0;
-        var customResolverConsumedPath = false;
 
-        for (var i = 0; i < nameSegments.Length && !customResolverConsumedPath; i++)
+        foreach (var segment in segments.TakeWhile(_ => !state.ResolverConsumedPath))
         {
-            var segment = nameSegments[i];
-
             if (currentPathLength > 0)
                 currentPathLength++; // account for dot
-
             currentPathLength += segment.Length;
-            var propertyPath = path.AsMemory(0, currentPathLength).ToString();
 
-            var metadataFound = metadataProvider.TryGetPropertyByDisplayName(currentType, segment, out var resolvedPropInfo);
-            if (metadataFound && resolvedPropInfo!.Mode != RqlPropertyMode.Ignored)
-            {
-                // Standard CLR property resolution
-                propInfo = resolvedPropInfo;
-                currentType = resolvedPropInfo.Property.PropertyType;
-                pathExpression = Expression.MakeMemberAccess(pathExpression, resolvedPropInfo.Property);
-            }
-            else if (!metadataFound && propInfo?.CustomResolver != null)
-            {
-                // Hand the resolver this segment AND every remaining segment as one dotted key.
-                // This lets resolvers translate a deep path (e.g. "$.a.b.c") in a single
-                // call and produce one scalar leaf expression.
-                var remainingSegments = string.Join('.', nameSegments, i, nameSegments.Length - i);
-                if (!TryResolveCustomProperty(propInfo, pathExpression, remainingSegments, out var resolvedExpr, out var customPropInfo))
-                    return Error.Validation("Invalid property path.", builderContext.GetFullPath(path));
+            var advanceState = AdvanceSegment(state, segment, path, currentPathLength);
+            if (advanceState.IsError)
+                return advanceState.Errors;
+            state = advanceState.Value;
 
-                propInfo = CreateFromCustomResolver(customPropInfo);
-                pathExpression = resolvedExpr;
-                propertyPath = path; // validation messages reference the full path the resolver consumed
-                customResolverConsumedPath = true;
-            }
-            else
-            {
-                return Error.Validation("Invalid property path.", builderContext.GetFullPath(propertyPath));
-            }
+            var validation = ValidatePath(state.PropInfo!, state.PropertyPath);
+            if (validation.IsError)
+                return validation.Errors;
 
-            var validationResult = ValidatePath(propInfo, propertyPath);
-
-            if (validationResult.IsError)
-                return validationResult.Errors;
-
-            if (safeNavigation)
-            {
-                // register member access expressions for further processing
-                memberAccess!.Add(pathExpression);
-            }
+            memberAccess.Add(state.Expression);
         }
 
-        if (safeNavigation)
+        var finalExpression = UseSafeNavigation()
+            ? BuildConditionalExpression(memberAccess, 0)
+            : state.Expression;
+
+        return new MemberPathInfo(state.PropInfo!, finalExpression);
+    }
+
+    /// <summary>
+    /// Resolves one path segment against metadata or — if the segment has no CLR counterpart —
+    /// the parent property's custom resolver. Returns the advanced walk state or a validation error.
+    /// </summary>
+    private Result<PathWalkState> AdvanceSegment(PathWalkState state, string segment, string path, int currentPathLength)
+    {
+        var propertyPath = path[..currentPathLength];
+
+        if (metadataProvider.TryGetPropertyByDisplayName(state.CurrentType, segment, out var resolvedPropInfo))
         {
-            pathExpression = BuildConditionalExpression(memberAccess!, 0);
+            if (resolvedPropInfo!.Mode == RqlPropertyMode.Ignored)
+                return CreateInvalidPathValidationError(propertyPath);
+
+            return state with
+            {
+                PropInfo = resolvedPropInfo,
+                CurrentType = resolvedPropInfo.Property.PropertyType,
+                Expression = Expression.MakeMemberAccess(state.Expression, resolvedPropInfo.Property),
+                PropertyPath = propertyPath,
+            };
         }
 
-        return new MemberPathInfo(propInfo!, pathExpression);
+        if (state.PropInfo?.CustomResolver is null)
+            return CreateInvalidPathValidationError(propertyPath);
+
+        // Hand the resolver this segment AND every remaining segment as one dotted key, so it can
+        // translate a deep path (e.g. "$.a.b.c") in a single call and produce one scalar leaf.
+        var remainingSegments = path[(currentPathLength - segment.Length)..];
+        if (!TryResolveCustomProperty(state.PropInfo, state.Expression, remainingSegments, out var leaf, out var customPropInfo))
+            return CreateInvalidPathValidationError(path);
+
+        return state with
+        {
+            PropInfo = CreateFromCustomResolver(customPropInfo),
+            Expression = leaf,
+            PropertyPath = path, // validation messages reference the full path the resolver consumed
+            ResolverConsumedPath = true,
+        };
+
+        Result<PathWalkState> CreateInvalidPathValidationError(string invalidPath)
+        {
+            return Error.Validation("Invalid property path.", builderContext.GetFullPath(invalidPath));
+        }
+    }
+
+    private readonly record struct PathWalkState(
+        Expression Expression,
+        Type CurrentType,
+        RqlPropertyInfo? PropInfo,
+        string PropertyPath,
+        bool ResolverConsumedPath)
+    {
+        public static PathWalkState Initial(Expression root) => new(root, root.Type, null, string.Empty, false);
     }
 
     private static Expression BuildConditionalExpression(List<Expression> memberAccess, int index)

--- a/src/Mpt.Rql/Core/PathInfoBuilder.cs
+++ b/src/Mpt.Rql/Core/PathInfoBuilder.cs
@@ -1,6 +1,7 @@
 using Mpt.Rql.Abstractions;
 using Mpt.Rql.Abstractions.Argument;
 using Mpt.Rql.Abstractions.Argument.Pointer;
+using Mpt.Rql.Abstractions.Exception;
 using Mpt.Rql.Abstractions.Result;
 using Mpt.Rql.Core.Metadata;
 using Mpt.Rql.Services.Context;
@@ -8,7 +9,7 @@ using System.Linq.Expressions;
 
 namespace Mpt.Rql.Core;
 
-internal abstract class PathInfoBuilder(IMetadataProvider metadataProvider, IBuilderContext builderContext, IEnumerable<IRqlCustomPropertyResolver>? customPropertyResolvers = null) : IPathInfoBuilder
+internal abstract class PathInfoBuilder(IMetadataProvider metadataProvider, IBuilderContext builderContext, IExternalServiceAccessor externalServices) : IPathInfoBuilder
 {
     public Result<MemberPathInfo> Build(Expression root, RqlExpression rqlExpression)
     {
@@ -46,30 +47,42 @@ internal abstract class PathInfoBuilder(IMetadataProvider metadataProvider, IBui
         RqlPropertyInfo? propInfo = null;
         var pathExpression = root;
         var currentPathLength = 0;
+        var customResolverConsumedPath = false;
 
-        foreach (var segment in nameSegments)
+        for (var i = 0; i < nameSegments.Length && !customResolverConsumedPath; i++)
         {
+            var segment = nameSegments[i];
+
             if (currentPathLength > 0)
                 currentPathLength++; // account for dot
 
             currentPathLength += segment.Length;
             var propertyPath = path.AsMemory(0, currentPathLength).ToString();
 
-            if (metadataProvider.TryGetPropertyByDisplayName(currentType, segment, out propInfo) && propInfo!.Mode != RqlPropertyMode.Ignored)
+            var metadataFound = metadataProvider.TryGetPropertyByDisplayName(currentType, segment, out var resolvedPropInfo);
+            if (metadataFound && resolvedPropInfo!.Mode != RqlPropertyMode.Ignored)
             {
                 // Standard CLR property resolution
-                currentType = propInfo.Property.PropertyType;
-                pathExpression = Expression.MakeMemberAccess(pathExpression, propInfo.Property);
+                propInfo = resolvedPropInfo;
+                currentType = resolvedPropInfo.Property.PropertyType;
+                pathExpression = Expression.MakeMemberAccess(pathExpression, resolvedPropInfo.Property);
             }
-            else if (TryResolveCustomProperty(pathExpression, segment, out var resolvedExpr, out var resolvedPropInfo))
+            else if (!metadataFound && propInfo?.CustomResolver != null)
             {
-                // Custom resolver handled this segment (e.g. JSON_VALUE)
-                propInfo = CreateFromCustomResolver(resolvedPropInfo);
-                pathExpression = resolvedExpr;
+                // Hand the resolver this segment AND every remaining segment as one dotted key.
+                // This lets resolvers translate a deep path (e.g. "$.a.b.c") in a single
+                // call and produce one scalar leaf expression.
+                var remainingSegments = i == nameSegments.Length - 1
+                    ? segment
+                    : string.Join('.', nameSegments, i, nameSegments.Length - i);
 
-                // Custom resolvers produce leaf expressions — no further dot-navigation. Nested property access is out of scope.
-                if (currentPathLength < path.Length)
-                    return Error.Validation("Nested property access on custom-resolved properties is not supported.", builderContext.GetFullPath(propertyPath));
+                if (!TryResolveCustomProperty(propInfo, pathExpression, remainingSegments, out var resolvedExpr, out var customPropInfo))
+                    return Error.Validation("Invalid property path.", builderContext.GetFullPath(path));
+
+                propInfo = CreateFromCustomResolver(customPropInfo);
+                pathExpression = resolvedExpr;
+                propertyPath = path; // validation messages reference the full path the resolver consumed
+                customResolverConsumedPath = true;
             }
             else
             {
@@ -139,21 +152,23 @@ internal abstract class PathInfoBuilder(IMetadataProvider metadataProvider, IBui
         IsNullable = source.IsNullable
     };
 
-    private bool TryResolveCustomProperty(Expression parentExpression, string propertyName,
-        out Expression resolvedExpression, out IRqlPropertyInfo resolvedPropertyInfo)
+    private bool TryResolveCustomProperty(
+        RqlPropertyInfo ownerPropertyInfo,
+        Expression parentExpression,
+        string propertyPath,
+        out Expression resolvedExpression,
+        out IRqlPropertyInfo resolvedPropertyInfo)
     {
-        if (customPropertyResolvers != null)
+        var resolverType = ownerPropertyInfo.CustomResolver!;
+        if (externalServices.GetService(resolverType) is not IRqlCustomPropertyResolver resolver)
         {
-            foreach (var resolver in customPropertyResolvers)
-            {
-                if (resolver.TryResolve(parentExpression, propertyName, out resolvedExpression, out resolvedPropertyInfo))
-                    return true;
-            }
+            throw new RqlInvalidCustomResolverException(
+                $"The instance of type {resolverType.FullName} defined as custom resolver for property " +
+                $"({ownerPropertyInfo.Property!.DeclaringType!.FullName}).{ownerPropertyInfo.Property.Name} " +
+                $"cannot be found. Make sure that service has been registered.");
         }
 
-        resolvedExpression = null!;
-        resolvedPropertyInfo = null!;
-        return false;
+        return resolver.TryResolve(parentExpression, propertyPath, out resolvedExpression, out resolvedPropertyInfo);
     }
 
     protected abstract Result<bool> ValidatePath(RqlPropertyInfo property, string path);

--- a/src/Mpt.Rql/Core/PathInfoBuilder.cs
+++ b/src/Mpt.Rql/Core/PathInfoBuilder.cs
@@ -72,10 +72,7 @@ internal abstract class PathInfoBuilder(IMetadataProvider metadataProvider, IBui
                 // Hand the resolver this segment AND every remaining segment as one dotted key.
                 // This lets resolvers translate a deep path (e.g. "$.a.b.c") in a single
                 // call and produce one scalar leaf expression.
-                var remainingSegments = i == nameSegments.Length - 1
-                    ? segment
-                    : string.Join('.', nameSegments, i, nameSegments.Length - i);
-
+                var remainingSegments = string.Join('.', nameSegments, i, nameSegments.Length - i);
                 if (!TryResolveCustomProperty(propInfo, pathExpression, remainingSegments, out var resolvedExpr, out var customPropInfo))
                     return Error.Validation("Invalid property path.", builderContext.GetFullPath(path));
 

--- a/src/Mpt.Rql/Core/PathInfoBuilder.cs
+++ b/src/Mpt.Rql/Core/PathInfoBuilder.cs
@@ -8,7 +8,7 @@ using System.Linq.Expressions;
 
 namespace Mpt.Rql.Core;
 
-internal abstract class PathInfoBuilder(IMetadataProvider metadataProvider, IBuilderContext builderContext) : IPathInfoBuilder
+internal abstract class PathInfoBuilder(IMetadataProvider metadataProvider, IBuilderContext builderContext, IEnumerable<IRqlCustomPropertyResolver>? customPropertyResolvers = null) : IPathInfoBuilder
 {
     public Result<MemberPathInfo> Build(Expression root, RqlExpression rqlExpression)
     {
@@ -55,7 +55,23 @@ internal abstract class PathInfoBuilder(IMetadataProvider metadataProvider, IBui
             currentPathLength += segment.Length;
             var propertyPath = path.AsMemory(0, currentPathLength).ToString();
 
-            if (!metadataProvider.TryGetPropertyByDisplayName(currentType, segment, out propInfo) || propInfo!.Mode == RqlPropertyMode.Ignored)
+            if (metadataProvider.TryGetPropertyByDisplayName(currentType, segment, out propInfo) && propInfo!.Mode != RqlPropertyMode.Ignored)
+            {
+                // Standard CLR property resolution
+                currentType = propInfo.Property.PropertyType;
+                pathExpression = Expression.MakeMemberAccess(pathExpression, propInfo.Property);
+            }
+            else if (TryResolveCustomProperty(pathExpression, segment, out var resolvedExpr, out var resolvedPropInfo))
+            {
+                // Custom resolver handled this segment (e.g. JSON_VALUE)
+                propInfo = CreateFromCustomResolver(resolvedPropInfo);
+                pathExpression = resolvedExpr;
+
+                // Custom resolvers produce leaf expressions — no further dot-navigation. Nested property access is out of scope.
+                if (currentPathLength < path.Length)
+                    return Error.Validation("Nested property access on custom-resolved properties is not supported.", builderContext.GetFullPath(propertyPath));
+            }
+            else
             {
                 return Error.Validation("Invalid property path.", builderContext.GetFullPath(propertyPath));
             }
@@ -64,9 +80,6 @@ internal abstract class PathInfoBuilder(IMetadataProvider metadataProvider, IBui
 
             if (validationResult.IsError)
                 return validationResult.Errors;
-
-            currentType = propInfo.Property.PropertyType;
-            pathExpression = Expression.MakeMemberAccess(pathExpression, propInfo!.Property!);
 
             if (safeNavigation)
             {
@@ -106,6 +119,41 @@ internal abstract class PathInfoBuilder(IMetadataProvider metadataProvider, IBui
             Expression.Equal(currentAccess, Expression.Constant(null, currentAccess.Type)),
             Expression.Constant(null, nextAccessType),
             nextAccess);
+    }
+
+    /// <summary>
+    /// Creates an internal <see cref="RqlPropertyInfo"/> from a custom resolver's <see cref="IRqlPropertyInfo"/>.
+    /// All fields are copied from the source as-is.
+    /// </summary>
+    private static RqlPropertyInfo CreateFromCustomResolver(IRqlPropertyInfo source) => new()
+    {
+        Name = source.Name,
+        Property = source.Property,
+        Mode = source.Mode,
+        Type = source.Type,
+        IsCore = source.IsCore,
+        SelectModeOverride = source.SelectModeOverride,
+        Actions = source.Actions,
+        Operators = source.Operators,
+        ElementType = source.ElementType,
+        IsNullable = source.IsNullable
+    };
+
+    private bool TryResolveCustomProperty(Expression parentExpression, string propertyName,
+        out Expression resolvedExpression, out IRqlPropertyInfo resolvedPropertyInfo)
+    {
+        if (customPropertyResolvers != null)
+        {
+            foreach (var resolver in customPropertyResolvers)
+            {
+                if (resolver.TryResolve(parentExpression, propertyName, out resolvedExpression, out resolvedPropertyInfo))
+                    return true;
+            }
+        }
+
+        resolvedExpression = null!;
+        resolvedPropertyInfo = null!;
+        return false;
     }
 
     protected abstract Result<bool> ValidatePath(RqlPropertyInfo property, string path);

--- a/src/Mpt.Rql/Core/RqlPropertyInfo.cs
+++ b/src/Mpt.Rql/Core/RqlPropertyInfo.cs
@@ -15,6 +15,7 @@ internal class RqlPropertyInfo : IRqlPropertyInfo
     public RqlActions Actions { get; internal set; }
     public RqlOperators Operators { get; internal set; }
     public Type? ActionStrategy { get; internal set; }
+    public Type? CustomResolver { get; internal set; }
     public Type? ElementType { get; internal set; }
     public bool IsNullable { get; internal set; }
 

--- a/src/Mpt.Rql/Services/Filtering/FilteringPathInfoBuilder.cs
+++ b/src/Mpt.Rql/Services/Filtering/FilteringPathInfoBuilder.cs
@@ -1,4 +1,3 @@
-using Mpt.Rql.Abstractions;
 using Mpt.Rql.Abstractions.Configuration;
 using Mpt.Rql.Abstractions.Result;
 using Mpt.Rql.Core;
@@ -9,8 +8,8 @@ namespace Mpt.Rql.Services.Filtering;
 
 internal interface IFilteringPathInfoBuilder : IPathInfoBuilder { }
 
-internal class FilteringPathInfoBuilder(IActionValidator actionValidator, IMetadataProvider metadataProvider, IBuilderContext builderContext, IRqlSettings settings, IEnumerable<IRqlCustomPropertyResolver>? customPropertyResolvers = null)
-    : PathInfoBuilder(metadataProvider, builderContext, customPropertyResolvers), IFilteringPathInfoBuilder
+internal class FilteringPathInfoBuilder(IActionValidator actionValidator, IMetadataProvider metadataProvider, IBuilderContext builderContext, IRqlSettings settings, IExternalServiceAccessor externalServices)
+    : PathInfoBuilder(metadataProvider, builderContext, externalServices), IFilteringPathInfoBuilder
 {
     private readonly IActionValidator _actionValidator = actionValidator;
     private readonly IBuilderContext _builderContext = builderContext;

--- a/src/Mpt.Rql/Services/Filtering/FilteringPathInfoBuilder.cs
+++ b/src/Mpt.Rql/Services/Filtering/FilteringPathInfoBuilder.cs
@@ -1,3 +1,4 @@
+using Mpt.Rql.Abstractions;
 using Mpt.Rql.Abstractions.Configuration;
 using Mpt.Rql.Abstractions.Result;
 using Mpt.Rql.Core;
@@ -8,8 +9,8 @@ namespace Mpt.Rql.Services.Filtering;
 
 internal interface IFilteringPathInfoBuilder : IPathInfoBuilder { }
 
-internal class FilteringPathInfoBuilder(IActionValidator actionValidator, IMetadataProvider metadataProvider, IBuilderContext builderContext, IRqlSettings settings)
-    : PathInfoBuilder(metadataProvider, builderContext), IFilteringPathInfoBuilder
+internal class FilteringPathInfoBuilder(IActionValidator actionValidator, IMetadataProvider metadataProvider, IBuilderContext builderContext, IRqlSettings settings, IEnumerable<IRqlCustomPropertyResolver>? customPropertyResolvers = null)
+    : PathInfoBuilder(metadataProvider, builderContext, customPropertyResolvers), IFilteringPathInfoBuilder
 {
     private readonly IActionValidator _actionValidator = actionValidator;
     private readonly IBuilderContext _builderContext = builderContext;

--- a/src/Mpt.Rql/Services/Ordering/OrderingPathInfoBuilder.cs
+++ b/src/Mpt.Rql/Services/Ordering/OrderingPathInfoBuilder.cs
@@ -8,8 +8,8 @@ namespace Mpt.Rql.Services.Ordering;
 
 internal interface IOrderingPathInfoBuilder : IPathInfoBuilder { }
 
-internal class OrderingPathInfoBuilder(IActionValidator actionValidator, IMetadataProvider metadataProvider, IBuilderContext builderContext, IRqlSettings settings)
-    : PathInfoBuilder(metadataProvider, builderContext), IOrderingPathInfoBuilder
+internal class OrderingPathInfoBuilder(IActionValidator actionValidator, IMetadataProvider metadataProvider, IBuilderContext builderContext, IRqlSettings settings, IExternalServiceAccessor externalServices)
+    : PathInfoBuilder(metadataProvider, builderContext, externalServices), IOrderingPathInfoBuilder
 {
     private readonly IActionValidator _actionValidator = actionValidator;
     private readonly IBuilderContext _builderContext = builderContext;

--- a/tests/Rql.Tests.Common/Factory/PathBuilderFactory.cs
+++ b/tests/Rql.Tests.Common/Factory/PathBuilderFactory.cs
@@ -1,3 +1,5 @@
+using Moq;
+using Mpt.Rql.Core;
 using Mpt.Rql.Services.Context;
 using Mpt.Rql.Services.Filtering;
 
@@ -7,7 +9,11 @@ internal static class PathBuilderFactory
 {
     internal static IFilteringPathInfoBuilder Internal()
     {
-        return new FilteringPathInfoBuilder(new SimpleActionValidator(), MetadataProviderFactory.Internal(), new BuilderContext(), RqlSettingsFactory.Default());
+        return new FilteringPathInfoBuilder(
+            new SimpleActionValidator(),
+            MetadataProviderFactory.Internal(),
+            new BuilderContext(),
+            RqlSettingsFactory.Default(),
+            Mock.Of<IExternalServiceAccessor>());
     }
 }
-

--- a/tests/Rql.Tests.Unit/Filtering/CustomPropertyResolverTests.cs
+++ b/tests/Rql.Tests.Unit/Filtering/CustomPropertyResolverTests.cs
@@ -1,0 +1,281 @@
+using FluentAssertions;
+using Moq;
+using Mpt.Rql;
+using Mpt.Rql.Abstractions;
+using Mpt.Rql.Core;
+using Mpt.Rql.Services.Context;
+using Mpt.Rql.Services.Filtering;
+using Rql.Tests.Common.Factory;
+using System.Linq.Expressions;
+using System.Text.Json;
+using Xunit;
+
+namespace Rql.Tests.Unit.Filtering;
+
+public class CustomPropertyResolverTests
+{
+    private static FilteringPathInfoBuilder CreateSut(params IRqlCustomPropertyResolver[] resolvers)
+    {
+        return new FilteringPathInfoBuilder(
+            new SimpleActionValidator(),
+            MetadataProviderFactory.Internal(),
+            new BuilderContext(),
+            RqlSettingsFactory.Default(),
+            resolvers);
+    }
+
+    private static FilteringPathInfoBuilder CreateSutWithNullResolvers()
+    {
+        return new FilteringPathInfoBuilder(
+            new SimpleActionValidator(),
+            MetadataProviderFactory.Internal(),
+            new BuilderContext(),
+            RqlSettingsFactory.Default(),
+            null);
+    }
+
+    [Fact]
+    public void Build_WithResolver_WhenMetadataFails_CallsResolverAndReturnsResult()
+    {
+        // Arrange
+        var resolverMock = new Mock<IRqlCustomPropertyResolver>();
+        var expectedExpression = Expression.Constant("resolved", typeof(string));
+        resolverMock
+            .Setup(r => r.TryResolve(It.IsAny<Expression>(), "dynamicProp", out It.Ref<Expression>.IsAny, out It.Ref<IRqlPropertyInfo>.IsAny))
+            .Returns((Expression parent, string name, out Expression expr, out IRqlPropertyInfo info) =>
+            {
+                expr = expectedExpression;
+                info = CreateSyntheticPropertyInfo(name);
+                return true;
+            });
+
+        var sut = CreateSut(resolverMock.Object);
+        var root = Expression.Parameter(typeof(EntityWithJson), "e");
+
+        // Act — "jsonProp.dynamicProp" : first segment resolves via metadata, second via resolver
+        var result = sut.Build(root, "jsonProp.dynamicProp");
+
+        // Assert
+        result.IsError.Should().BeFalse();
+        result.Value!.PropertyInfo.Name.Should().Be("dynamicProp");
+        result.Value.Expression.Should().BeSameAs(expectedExpression);
+        resolverMock.Verify(r => r.TryResolve(It.IsAny<Expression>(), "dynamicProp", out It.Ref<Expression>.IsAny, out It.Ref<IRqlPropertyInfo>.IsAny), Times.Once);
+    }
+
+    [Fact]
+    public void Build_WithResolver_WhenResolverReturnsFalse_ReturnsInvalidPropertyPathError()
+    {
+        // Arrange
+        var resolverMock = new Mock<IRqlCustomPropertyResolver>();
+        resolverMock
+            .Setup(r => r.TryResolve(It.IsAny<Expression>(), It.IsAny<string>(), out It.Ref<Expression>.IsAny, out It.Ref<IRqlPropertyInfo>.IsAny))
+            .Returns(false);
+
+        var sut = CreateSut(resolverMock.Object);
+        var root = Expression.Parameter(typeof(EntityWithJson), "e");
+
+        // Act
+        var result = sut.Build(root, "jsonProp.unknownKey");
+
+        // Assert
+        result.IsError.Should().BeTrue();
+        result.Errors.Should().Contain(e => e.Message.Contains("Invalid property path"));
+    }
+
+    [Fact]
+    public void Build_WithNoResolvers_UnknownProperty_ReturnsInvalidPropertyPathError()
+    {
+        // Arrange — empty array of resolvers
+        var sut = CreateSut();
+        var root = Expression.Parameter(typeof(EntityWithJson), "e");
+
+        // Act
+        var result = sut.Build(root, "jsonProp.unknownKey");
+
+        // Assert
+        result.IsError.Should().BeTrue();
+        result.Errors.Should().Contain(e => e.Message.Contains("Invalid property path"));
+    }
+
+    [Fact]
+    public void Build_WithNullResolvers_UnknownProperty_ReturnsError()
+    {
+        // Arrange — null resolvers (matches DI behavior when none are registered)
+        var sut = CreateSutWithNullResolvers();
+        var root = Expression.Parameter(typeof(EntityWithJson), "e");
+
+        // Act
+        var result = sut.Build(root, "jsonProp.unknownKey");
+
+        // Assert
+        result.IsError.Should().BeTrue();
+        result.Errors.Should().Contain(e => e.Message.Contains("Invalid property path"));
+    }
+
+    [Fact]
+    public void Build_WithMultipleResolvers_FirstMatchWins()
+    {
+        // Arrange
+        var resolver1 = new Mock<IRqlCustomPropertyResolver>();
+        resolver1
+            .Setup(r => r.TryResolve(It.IsAny<Expression>(), "dynamicProp", out It.Ref<Expression>.IsAny, out It.Ref<IRqlPropertyInfo>.IsAny))
+            .Returns((Expression parent, string name, out Expression expr, out IRqlPropertyInfo info) =>
+            {
+                expr = Expression.Constant("from-resolver-1", typeof(string));
+                info = CreateSyntheticPropertyInfo("fromResolver1");
+                return true;
+            });
+
+        var resolver2 = new Mock<IRqlCustomPropertyResolver>();
+
+        var sut = CreateSut(resolver1.Object, resolver2.Object);
+        var root = Expression.Parameter(typeof(EntityWithJson), "e");
+
+        // Act
+        var result = sut.Build(root, "jsonProp.dynamicProp");
+
+        // Assert
+        result.IsError.Should().BeFalse();
+        result.Value!.PropertyInfo.Name.Should().Be("fromResolver1");
+        resolver1.Verify(r => r.TryResolve(It.IsAny<Expression>(), "dynamicProp", out It.Ref<Expression>.IsAny, out It.Ref<IRqlPropertyInfo>.IsAny), Times.Once);
+        resolver2.Verify(r => r.TryResolve(It.IsAny<Expression>(), It.IsAny<string>(), out It.Ref<Expression>.IsAny, out It.Ref<IRqlPropertyInfo>.IsAny), Times.Never);
+    }
+
+    [Fact]
+    public void Build_WithMultipleResolvers_FallsThrough_WhenFirstReturnsFalse()
+    {
+        // Arrange
+        var resolver1 = new Mock<IRqlCustomPropertyResolver>();
+        resolver1
+            .Setup(r => r.TryResolve(It.IsAny<Expression>(), It.IsAny<string>(), out It.Ref<Expression>.IsAny, out It.Ref<IRqlPropertyInfo>.IsAny))
+            .Returns(false);
+
+        var resolver2 = new Mock<IRqlCustomPropertyResolver>();
+        resolver2
+            .Setup(r => r.TryResolve(It.IsAny<Expression>(), "dynamicProp", out It.Ref<Expression>.IsAny, out It.Ref<IRqlPropertyInfo>.IsAny))
+            .Returns((Expression parent, string name, out Expression expr, out IRqlPropertyInfo info) =>
+            {
+                expr = Expression.Constant("from-resolver-2", typeof(string));
+                info = CreateSyntheticPropertyInfo("fromResolver2");
+                return true;
+            });
+
+        var sut = CreateSut(resolver1.Object, resolver2.Object);
+        var root = Expression.Parameter(typeof(EntityWithJson), "e");
+
+        // Act
+        var result = sut.Build(root, "jsonProp.dynamicProp");
+
+        // Assert
+        result.IsError.Should().BeFalse();
+        result.Value!.PropertyInfo.Name.Should().Be("fromResolver2");
+    }
+
+    [Fact]
+    public void Build_NestedPathAfterResolvedProperty_ReturnsNestedAccessError()
+    {
+        // Arrange — resolver handles "dynamicProp", but then "nested" follows
+        var resolverMock = new Mock<IRqlCustomPropertyResolver>();
+        resolverMock
+            .Setup(r => r.TryResolve(It.IsAny<Expression>(), "dynamicProp", out It.Ref<Expression>.IsAny, out It.Ref<IRqlPropertyInfo>.IsAny))
+            .Returns((Expression parent, string name, out Expression expr, out IRqlPropertyInfo info) =>
+            {
+                expr = Expression.Constant("resolved", typeof(string));
+                info = CreateSyntheticPropertyInfo(name);
+                return true;
+            });
+
+        var sut = CreateSut(resolverMock.Object);
+        var root = Expression.Parameter(typeof(EntityWithJson), "e");
+
+        // Act — "jsonProp.dynamicProp.nested" should fail on "nested"
+        var result = sut.Build(root, "jsonProp.dynamicProp.nested");
+
+        // Assert
+        result.IsError.Should().BeTrue();
+        result.Errors.Should().Contain(e => e.Message.Contains("Nested property access"));
+    }
+
+    [Fact]
+    public void Build_ResolverPropertyWithoutFilterAction_ReturnsFilteringNotPermittedError()
+    {
+        // Arrange — resolver returns a property with Select-only actions
+        var resolverMock = new Mock<IRqlCustomPropertyResolver>();
+        resolverMock
+            .Setup(r => r.TryResolve(It.IsAny<Expression>(), "dynamicProp", out It.Ref<Expression>.IsAny, out It.Ref<IRqlPropertyInfo>.IsAny))
+            .Returns((Expression parent, string name, out Expression expr, out IRqlPropertyInfo info) =>
+            {
+                expr = Expression.Constant("resolved", typeof(string));
+                info = CreateSyntheticPropertyInfo(name, RqlActions.Select); // no Filter
+                return true;
+            });
+
+        var sut = CreateSut(resolverMock.Object);
+        var root = Expression.Parameter(typeof(EntityWithJson), "e");
+
+        // Act
+        var result = sut.Build(root, "jsonProp.dynamicProp");
+
+        // Assert
+        result.IsError.Should().BeTrue();
+        result.Errors.Should().Contain(e => e.Message.Contains("Filtering is not permitted"));
+    }
+
+    [Fact]
+    public void Build_StandardClrPath_WithResolversRegistered_DoesNotCallResolver()
+    {
+        // Arrange — resolver is registered but "name" is a standard CLR property
+        var resolverMock = new Mock<IRqlCustomPropertyResolver>();
+
+        var sut = CreateSut(resolverMock.Object);
+        var root = Expression.Parameter(typeof(EntityWithJson), "e");
+
+        // Act
+        var result = sut.Build(root, "name");
+
+        // Assert
+        result.IsError.Should().BeFalse();
+        result.Value!.PropertyInfo.Name.Should().Be("name");
+        resolverMock.Verify(r => r.TryResolve(It.IsAny<Expression>(), It.IsAny<string>(), out It.Ref<Expression>.IsAny, out It.Ref<IRqlPropertyInfo>.IsAny), Times.Never);
+    }
+
+    [Fact]
+    public void Build_UnknownFirstSegment_CallsResolver()
+    {
+        // Arrange — "unknownRoot" doesn't exist on the entity, resolver should be tried
+        var resolverMock = new Mock<IRqlCustomPropertyResolver>();
+        resolverMock
+            .Setup(r => r.TryResolve(It.IsAny<Expression>(), "unknownRoot", out It.Ref<Expression>.IsAny, out It.Ref<IRqlPropertyInfo>.IsAny))
+            .Returns(false);
+
+        var sut = CreateSut(resolverMock.Object);
+        var root = Expression.Parameter(typeof(EntityWithJson), "e");
+
+        // Act
+        var result = sut.Build(root, "unknownRoot");
+
+        // Assert
+        result.IsError.Should().BeTrue();
+        resolverMock.Verify(r => r.TryResolve(It.IsAny<Expression>(), "unknownRoot", out It.Ref<Expression>.IsAny, out It.Ref<IRqlPropertyInfo>.IsAny), Times.Once);
+    }
+
+    private static IRqlPropertyInfo CreateSyntheticPropertyInfo(string name, RqlActions actions = RqlActions.Filter)
+    {
+        var mock = new Mock<IRqlPropertyInfo>();
+        mock.Setup(p => p.Name).Returns(name);
+        mock.Setup(p => p.Type).Returns(RqlPropertyType.Primitive);
+        mock.Setup(p => p.Actions).Returns(actions);
+        mock.Setup(p => p.Operators).Returns(RqlOperators.Eq | RqlOperators.Ne);
+        mock.Setup(p => p.IsNullable).Returns(true);
+        mock.Setup(p => p.Mode).Returns(RqlPropertyMode.Default);
+        return mock.Object;
+    }
+
+    // Test entity with a JsonElement property that metadata can resolve,
+    // but whose child properties require a custom resolver
+    public class EntityWithJson
+    {
+        public JsonElement? JsonProp { get; set; }
+        public string Name { get; set; } = null!;
+    }
+}

--- a/tests/Rql.Tests.Unit/Filtering/CustomPropertyResolverTests.cs
+++ b/tests/Rql.Tests.Unit/Filtering/CustomPropertyResolverTests.cs
@@ -2,7 +2,9 @@ using FluentAssertions;
 using Moq;
 using Mpt.Rql;
 using Mpt.Rql.Abstractions;
+using Mpt.Rql.Abstractions.Exception;
 using Mpt.Rql.Core;
+using Mpt.Rql.Core.Metadata;
 using Mpt.Rql.Services.Context;
 using Mpt.Rql.Services.Filtering;
 using Rql.Tests.Common.Factory;
@@ -14,28 +16,27 @@ namespace Rql.Tests.Unit.Filtering;
 
 public class CustomPropertyResolverTests
 {
-    private static FilteringPathInfoBuilder CreateSut(params IRqlCustomPropertyResolver[] resolvers)
+    private static FilteringPathInfoBuilder CreateSut(Mock<IExternalServiceAccessor>? externalServicesMock = null)
     {
+        externalServicesMock ??= new Mock<IExternalServiceAccessor>();
         return new FilteringPathInfoBuilder(
             new SimpleActionValidator(),
             MetadataProviderFactory.Internal(),
             new BuilderContext(),
             RqlSettingsFactory.Default(),
-            resolvers);
+            externalServicesMock.Object);
     }
 
-    private static FilteringPathInfoBuilder CreateSutWithNullResolvers()
+    private static Mock<IExternalServiceAccessor> RegisterResolver<TResolver>(IRqlCustomPropertyResolver resolver)
+        where TResolver : IRqlCustomPropertyResolver
     {
-        return new FilteringPathInfoBuilder(
-            new SimpleActionValidator(),
-            MetadataProviderFactory.Internal(),
-            new BuilderContext(),
-            RqlSettingsFactory.Default(),
-            null);
+        var mock = new Mock<IExternalServiceAccessor>();
+        mock.Setup(s => s.GetService(typeof(TResolver))).Returns(resolver);
+        return mock;
     }
 
     [Fact]
-    public void Build_WithResolver_WhenMetadataFails_CallsResolverAndReturnsResult()
+    public void Build_WithCustomResolverOnParent_WhenChildSegmentFailsMetadata_CallsResolverAndReturnsResult()
     {
         // Arrange
         var resolverMock = new Mock<IRqlCustomPropertyResolver>();
@@ -49,10 +50,10 @@ public class CustomPropertyResolverTests
                 return true;
             });
 
-        var sut = CreateSut(resolverMock.Object);
+        var sut = CreateSut(RegisterResolver<ITestResolver>(resolverMock.Object));
         var root = Expression.Parameter(typeof(EntityWithJson), "e");
 
-        // Act — "jsonProp.dynamicProp" : first segment resolves via metadata, second via resolver
+        // Act — "jsonProp.dynamicProp" : first segment resolves via metadata (carries CustomResolver), second via resolver
         var result = sut.Build(root, "jsonProp.dynamicProp");
 
         // Assert
@@ -63,7 +64,7 @@ public class CustomPropertyResolverTests
     }
 
     [Fact]
-    public void Build_WithResolver_WhenResolverReturnsFalse_ReturnsInvalidPropertyPathError()
+    public void Build_WithCustomResolver_WhenResolverReturnsFalse_ReturnsInvalidPropertyPathError()
     {
         // Arrange
         var resolverMock = new Mock<IRqlCustomPropertyResolver>();
@@ -71,7 +72,7 @@ public class CustomPropertyResolverTests
             .Setup(r => r.TryResolve(It.IsAny<Expression>(), It.IsAny<string>(), out It.Ref<Expression>.IsAny, out It.Ref<IRqlPropertyInfo>.IsAny))
             .Returns(false);
 
-        var sut = CreateSut(resolverMock.Object);
+        var sut = CreateSut(RegisterResolver<ITestResolver>(resolverMock.Object));
         var root = Expression.Parameter(typeof(EntityWithJson), "e");
 
         // Act
@@ -83,117 +84,143 @@ public class CustomPropertyResolverTests
     }
 
     [Fact]
-    public void Build_WithNoResolvers_UnknownProperty_ReturnsInvalidPropertyPathError()
+    public void Build_PropertyWithoutCustomResolver_ChildSegmentFails_ReturnsInvalidPropertyPathError()
     {
-        // Arrange — empty array of resolvers
-        var sut = CreateSut();
+        // Arrange — plainJson has no CustomResolver attribute, so child segment must fail
+        var resolverMock = new Mock<IRqlCustomPropertyResolver>();
+        var sut = CreateSut(RegisterResolver<ITestResolver>(resolverMock.Object));
         var root = Expression.Parameter(typeof(EntityWithJson), "e");
 
         // Act
-        var result = sut.Build(root, "jsonProp.unknownKey");
+        var result = sut.Build(root, "plainJson.dynamicProp");
 
         // Assert
         result.IsError.Should().BeTrue();
         result.Errors.Should().Contain(e => e.Message.Contains("Invalid property path"));
+        resolverMock.Verify(r => r.TryResolve(It.IsAny<Expression>(), It.IsAny<string>(), out It.Ref<Expression>.IsAny, out It.Ref<IRqlPropertyInfo>.IsAny), Times.Never);
     }
 
     [Fact]
-    public void Build_WithNullResolvers_UnknownProperty_ReturnsError()
+    public void Build_NestedPathAfterResolverBoundary_ForwardsFullDottedKeyToResolver()
     {
-        // Arrange — null resolvers (matches DI behavior when none are registered)
-        var sut = CreateSutWithNullResolvers();
-        var root = Expression.Parameter(typeof(EntityWithJson), "e");
+        // Segments after the resolver-annotated property are concatenated and handed to the resolver
+        // in one call. The resolver decides whether to translate the dotted key (e.g. into a
+        // JSON_VALUE('$.a.b.c') call) or reject it.
 
-        // Act
-        var result = sut.Build(root, "jsonProp.unknownKey");
-
-        // Assert
-        result.IsError.Should().BeTrue();
-        result.Errors.Should().Contain(e => e.Message.Contains("Invalid property path"));
-    }
-
-    [Fact]
-    public void Build_WithMultipleResolvers_FirstMatchWins()
-    {
         // Arrange
-        var resolver1 = new Mock<IRqlCustomPropertyResolver>();
-        resolver1
-            .Setup(r => r.TryResolve(It.IsAny<Expression>(), "dynamicProp", out It.Ref<Expression>.IsAny, out It.Ref<IRqlPropertyInfo>.IsAny))
+        var resolverMock = new Mock<IRqlCustomPropertyResolver>();
+        var leaf = Expression.Constant("resolved", typeof(string));
+        resolverMock
+            .Setup(r => r.TryResolve(It.IsAny<Expression>(), "a.b.c", out It.Ref<Expression>.IsAny, out It.Ref<IRqlPropertyInfo>.IsAny))
             .Returns((Expression parent, string name, out Expression expr, out IRqlPropertyInfo info) =>
             {
-                expr = Expression.Constant("from-resolver-1", typeof(string));
-                info = CreateSyntheticPropertyInfo("fromResolver1");
+                expr = leaf;
+                info = CreateSyntheticPropertyInfo(name);
                 return true;
             });
 
-        var resolver2 = new Mock<IRqlCustomPropertyResolver>();
-
-        var sut = CreateSut(resolver1.Object, resolver2.Object);
+        var sut = CreateSut(RegisterResolver<ITestResolver>(resolverMock.Object));
         var root = Expression.Parameter(typeof(EntityWithJson), "e");
 
-        // Act
-        var result = sut.Build(root, "jsonProp.dynamicProp");
+        // Act — resolver should receive "a.b.c" as a single dotted key
+        var result = sut.Build(root, "jsonProp.a.b.c");
 
         // Assert
         result.IsError.Should().BeFalse();
-        result.Value!.PropertyInfo.Name.Should().Be("fromResolver1");
-        resolver1.Verify(r => r.TryResolve(It.IsAny<Expression>(), "dynamicProp", out It.Ref<Expression>.IsAny, out It.Ref<IRqlPropertyInfo>.IsAny), Times.Once);
-        resolver2.Verify(r => r.TryResolve(It.IsAny<Expression>(), It.IsAny<string>(), out It.Ref<Expression>.IsAny, out It.Ref<IRqlPropertyInfo>.IsAny), Times.Never);
+        result.Value!.PropertyInfo.Name.Should().Be("a.b.c");
+        result.Value.Expression.Should().BeSameAs(leaf);
+        resolverMock.Verify(
+            r => r.TryResolve(It.IsAny<Expression>(), "a.b.c", out It.Ref<Expression>.IsAny, out It.Ref<IRqlPropertyInfo>.IsAny),
+            Times.Once);
     }
 
     [Fact]
-    public void Build_WithMultipleResolvers_FallsThrough_WhenFirstReturnsFalse()
+    public void Build_NestedPath_ResolverReceivesCarrierExpressionAsParent()
     {
+        // The parent expression handed to the resolver is the access to the CustomResolver-annotated
+        // property itself (e.g. `e.JsonProp`) — not any deeper node. That's the anchor the resolver
+        // needs to emit e.g. JSON_VALUE(e.JsonProp, '$.a.b').
+
         // Arrange
-        var resolver1 = new Mock<IRqlCustomPropertyResolver>();
-        resolver1
-            .Setup(r => r.TryResolve(It.IsAny<Expression>(), It.IsAny<string>(), out It.Ref<Expression>.IsAny, out It.Ref<IRqlPropertyInfo>.IsAny))
-            .Returns(false);
-
-        var resolver2 = new Mock<IRqlCustomPropertyResolver>();
-        resolver2
-            .Setup(r => r.TryResolve(It.IsAny<Expression>(), "dynamicProp", out It.Ref<Expression>.IsAny, out It.Ref<IRqlPropertyInfo>.IsAny))
-            .Returns((Expression parent, string name, out Expression expr, out IRqlPropertyInfo info) =>
-            {
-                expr = Expression.Constant("from-resolver-2", typeof(string));
-                info = CreateSyntheticPropertyInfo("fromResolver2");
-                return true;
-            });
-
-        var sut = CreateSut(resolver1.Object, resolver2.Object);
-        var root = Expression.Parameter(typeof(EntityWithJson), "e");
-
-        // Act
-        var result = sut.Build(root, "jsonProp.dynamicProp");
-
-        // Assert
-        result.IsError.Should().BeFalse();
-        result.Value!.PropertyInfo.Name.Should().Be("fromResolver2");
-    }
-
-    [Fact]
-    public void Build_NestedPathAfterResolvedProperty_ReturnsNestedAccessError()
-    {
-        // Arrange — resolver handles "dynamicProp", but then "nested" follows
+        Expression? capturedParent = null;
         var resolverMock = new Mock<IRqlCustomPropertyResolver>();
         resolverMock
-            .Setup(r => r.TryResolve(It.IsAny<Expression>(), "dynamicProp", out It.Ref<Expression>.IsAny, out It.Ref<IRqlPropertyInfo>.IsAny))
+            .Setup(r => r.TryResolve(It.IsAny<Expression>(), It.IsAny<string>(), out It.Ref<Expression>.IsAny, out It.Ref<IRqlPropertyInfo>.IsAny))
             .Returns((Expression parent, string name, out Expression expr, out IRqlPropertyInfo info) =>
             {
+                capturedParent = parent;
                 expr = Expression.Constant("resolved", typeof(string));
                 info = CreateSyntheticPropertyInfo(name);
                 return true;
             });
 
-        var sut = CreateSut(resolverMock.Object);
+        var sut = CreateSut(RegisterResolver<ITestResolver>(resolverMock.Object));
         var root = Expression.Parameter(typeof(EntityWithJson), "e");
 
-        // Act — "jsonProp.dynamicProp.nested" should fail on "nested"
-        var result = sut.Build(root, "jsonProp.dynamicProp.nested");
+        // Act
+        var result = sut.Build(root, "jsonProp.a.b");
+
+        // Assert — parent is `e.JsonProp` (the CustomResolver-annotated property access)
+        result.IsError.Should().BeFalse();
+        capturedParent.Should().BeAssignableTo<MemberExpression>();
+        var memberAccess = (MemberExpression)capturedParent!;
+        memberAccess.Member.Name.Should().Be(nameof(EntityWithJson.JsonProp));
+        memberAccess.Expression.Should().BeSameAs(root);
+    }
+
+    [Fact]
+    public void Build_NestedPath_ValidationError_ReferencesFullPath()
+    {
+        // When the resolver returns a synthetic property whose actions fail validation (e.g. Filter
+        // not permitted), the error location must reference the FULL dotted path the user sent —
+        // not the prefix at which the resolver boundary was crossed. Otherwise the error would
+        // mislead clients into thinking the issue is at a shorter path than what they actually sent.
+
+        // Arrange — resolver accepts the dotted key but returns Select-only actions
+        var resolverMock = new Mock<IRqlCustomPropertyResolver>();
+        resolverMock
+            .Setup(r => r.TryResolve(It.IsAny<Expression>(), "a.b.c", out It.Ref<Expression>.IsAny, out It.Ref<IRqlPropertyInfo>.IsAny))
+            .Returns((Expression parent, string name, out Expression expr, out IRqlPropertyInfo info) =>
+            {
+                expr = Expression.Constant("resolved", typeof(string));
+                info = CreateSyntheticPropertyInfo(name, RqlActions.Select);
+                return true;
+            });
+
+        var sut = CreateSut(RegisterResolver<ITestResolver>(resolverMock.Object));
+        var root = Expression.Parameter(typeof(EntityWithJson), "e");
+
+        // Act
+        var result = sut.Build(root, "jsonProp.a.b.c");
+
+        // Assert — error must mention the full path, not "jsonProp.a"
+        result.IsError.Should().BeTrue();
+        var error = result.Errors.Single();
+        error.Message.Should().Contain("Filtering is not permitted");
+        error.Code.Should().Contain("jsonProp.a.b.c");
+    }
+
+    [Fact]
+    public void Build_NestedPath_ResolverRejectsDottedKey_ReturnsInvalidPropertyPathError()
+    {
+        // Resolvers that don't support nested paths simply return false for dotted keys;
+        // the builder surfaces the standard "Invalid property path" error.
+
+        // Arrange
+        var resolverMock = new Mock<IRqlCustomPropertyResolver>();
+        resolverMock
+            .Setup(r => r.TryResolve(It.IsAny<Expression>(), It.IsAny<string>(), out It.Ref<Expression>.IsAny, out It.Ref<IRqlPropertyInfo>.IsAny))
+            .Returns(false);
+
+        var sut = CreateSut(RegisterResolver<ITestResolver>(resolverMock.Object));
+        var root = Expression.Parameter(typeof(EntityWithJson), "e");
+
+        // Act
+        var result = sut.Build(root, "jsonProp.unknown.nested");
 
         // Assert
         result.IsError.Should().BeTrue();
-        result.Errors.Should().Contain(e => e.Message.Contains("Nested property access"));
+        result.Errors.Should().Contain(e => e.Message.Contains("Invalid property path"));
     }
 
     [Fact]
@@ -210,7 +237,7 @@ public class CustomPropertyResolverTests
                 return true;
             });
 
-        var sut = CreateSut(resolverMock.Object);
+        var sut = CreateSut(RegisterResolver<ITestResolver>(resolverMock.Object));
         var root = Expression.Parameter(typeof(EntityWithJson), "e");
 
         // Act
@@ -222,12 +249,12 @@ public class CustomPropertyResolverTests
     }
 
     [Fact]
-    public void Build_StandardClrPath_WithResolversRegistered_DoesNotCallResolver()
+    public void Build_StandardClrPath_WithResolverRegistered_DoesNotCallResolver()
     {
-        // Arrange — resolver is registered but "name" is a standard CLR property
+        // Arrange — resolver is registered for jsonProp but "name" is a standard CLR property
         var resolverMock = new Mock<IRqlCustomPropertyResolver>();
 
-        var sut = CreateSut(resolverMock.Object);
+        var sut = CreateSut(RegisterResolver<ITestResolver>(resolverMock.Object));
         var root = Expression.Parameter(typeof(EntityWithJson), "e");
 
         // Act
@@ -240,15 +267,11 @@ public class CustomPropertyResolverTests
     }
 
     [Fact]
-    public void Build_UnknownFirstSegment_CallsResolver()
+    public void Build_UnknownRootSegment_DoesNotCallResolver_ReturnsError()
     {
-        // Arrange — "unknownRoot" doesn't exist on the entity, resolver should be tried
+        // Arrange — "unknownRoot" doesn't exist on the entity; no previous property with CustomResolver, so resolver is not called
         var resolverMock = new Mock<IRqlCustomPropertyResolver>();
-        resolverMock
-            .Setup(r => r.TryResolve(It.IsAny<Expression>(), "unknownRoot", out It.Ref<Expression>.IsAny, out It.Ref<IRqlPropertyInfo>.IsAny))
-            .Returns(false);
-
-        var sut = CreateSut(resolverMock.Object);
+        var sut = CreateSut(RegisterResolver<ITestResolver>(resolverMock.Object));
         var root = Expression.Parameter(typeof(EntityWithJson), "e");
 
         // Act
@@ -256,7 +279,72 @@ public class CustomPropertyResolverTests
 
         // Assert
         result.IsError.Should().BeTrue();
-        resolverMock.Verify(r => r.TryResolve(It.IsAny<Expression>(), "unknownRoot", out It.Ref<Expression>.IsAny, out It.Ref<IRqlPropertyInfo>.IsAny), Times.Once);
+        resolverMock.Verify(r => r.TryResolve(It.IsAny<Expression>(), It.IsAny<string>(), out It.Ref<Expression>.IsAny, out It.Ref<IRqlPropertyInfo>.IsAny), Times.Never);
+    }
+
+    [Fact]
+    public void Build_IgnoredCustomProperty_DoesNotFallThroughToResolver()
+    {
+        // An explicit `Mode = Ignored` on a CLR property must win over the parent's CustomResolver.
+        // Otherwise a property hidden by design could be silently re-exposed via the resolver's
+        // allowlist when the names happen to collide.
+
+        // Arrange — resolver is wired, but the segment name matches an Ignored CLR property on the JsonElement-parent entity.
+        var resolverMock = new Mock<IRqlCustomPropertyResolver>();
+        resolverMock
+            .Setup(r => r.TryResolve(It.IsAny<Expression>(), It.IsAny<string>(), out It.Ref<Expression>.IsAny, out It.Ref<IRqlPropertyInfo>.IsAny))
+            .Returns((Expression parent, string name, out Expression expr, out IRqlPropertyInfo info) =>
+            {
+                expr = Expression.Constant("from-resolver", typeof(string));
+                info = CreateSyntheticPropertyInfo(name);
+                return true;
+            });
+
+        var sut = CreateSut(RegisterResolver<ITestResolver>(resolverMock.Object));
+        var root = Expression.Parameter(typeof(EntityWithResolverCarrier), "e");
+
+        // Act — "resolverCarrier.hiddenField": hiddenField exists on ResolverCarrier but is marked Ignored.
+        var result = sut.Build(root, "resolverCarrier.hiddenField");
+
+        // Assert — Ignored wins; no fallback to resolver, standard invalid-path error.
+        result.IsError.Should().BeTrue();
+        result.Errors.Should().Contain(e => e.Message.Contains("Invalid property path"));
+        resolverMock.Verify(
+            r => r.TryResolve(It.IsAny<Expression>(), It.IsAny<string>(), out It.Ref<Expression>.IsAny, out It.Ref<IRqlPropertyInfo>.IsAny),
+            Times.Never);
+    }
+
+    [Fact]
+    public void MetadataFactory_CustomResolverTypeDoesNotImplementInterface_ThrowsInvalidCustomResolverException()
+    {
+        // Arrange — factory reads the attribute when building RqlPropertyInfo for a property
+        var factory = new MetadataFactory(RqlSettingsFactory.Default());
+        var property = typeof(EntityWithInvalidResolver).GetProperty(nameof(EntityWithInvalidResolver.Bad))!;
+
+        // Act
+        var act = () => factory.MakeRqlPropertyInfo("bad", property);
+
+        // Assert
+        act.Should().Throw<RqlInvalidCustomResolverException>()
+            .WithMessage("*does not implement*IRqlCustomPropertyResolver*");
+    }
+
+    [Fact]
+    public void Build_CustomResolverTypeNotRegistered_ThrowsInvalidCustomResolverException()
+    {
+        // Arrange — empty external services, so resolver type cannot be resolved
+        var externalServices = new Mock<IExternalServiceAccessor>();
+        externalServices.Setup(s => s.GetService(It.IsAny<Type>())).Returns((object?)null);
+
+        var sut = CreateSut(externalServices);
+        var root = Expression.Parameter(typeof(EntityWithJson), "e");
+
+        // Act
+        var act = () => sut.Build(root, "jsonProp.dynamicProp");
+
+        // Assert
+        act.Should().Throw<RqlInvalidCustomResolverException>()
+            .WithMessage("*cannot be found*");
     }
 
     private static IRqlPropertyInfo CreateSyntheticPropertyInfo(string name, RqlActions actions = RqlActions.Filter)
@@ -271,11 +359,43 @@ public class CustomPropertyResolverTests
         return mock.Object;
     }
 
-    // Test entity with a JsonElement property that metadata can resolve,
-    // but whose child properties require a custom resolver
+    // Marker interface representing a per-property resolver (mirrors how consumers wire this via DI).
+    public interface ITestResolver : IRqlCustomPropertyResolver { }
+
+    // Test entity:
+    //   - JsonProp: has CustomResolver — children are resolved dynamically
+    //   - PlainJson: no CustomResolver — children must fail
+    //   - Name: standard primitive — resolver should never be touched
     public class EntityWithJson
     {
+        [RqlProperty(CustomResolver = typeof(ITestResolver))]
         public JsonElement? JsonProp { get; set; }
+
+        public JsonElement? PlainJson { get; set; }
+
         public string Name { get; set; } = null!;
+    }
+
+    // Entity exercising the Ignored + CustomResolver interaction.
+    // `Carrier` carries the CustomResolver attribute; its child type exposes a CLR property
+    // marked Ignored. An `Ignored` marker must win over the resolver fallback — the resolver
+    // must NOT be invoked for that name.
+    public class EntityWithResolverCarrier
+    {
+        [RqlProperty(CustomResolver = typeof(ITestResolver))]
+        public ResolverCarrier ResolverCarrier { get; set; } = null!;
+    }
+
+    public class ResolverCarrier
+    {
+        [RqlProperty(Mode = RqlPropertyMode.Ignored)]
+        public string HiddenField { get; set; } = null!;
+    }
+
+    public class EntityWithInvalidResolver
+    {
+        // `object` does not implement IRqlCustomPropertyResolver — must be rejected at metadata build time.
+        [RqlProperty(CustomResolver = typeof(object))]
+        public JsonElement? Bad { get; set; }
     }
 }

--- a/tests/Rql.Tests.Unit/Ordering/CustomPropertyResolverOrderingTests.cs
+++ b/tests/Rql.Tests.Unit/Ordering/CustomPropertyResolverOrderingTests.cs
@@ -1,0 +1,132 @@
+using FluentAssertions;
+using Moq;
+using Mpt.Rql;
+using Mpt.Rql.Abstractions;
+using Mpt.Rql.Core;
+using Mpt.Rql.Services.Context;
+using Mpt.Rql.Services.Ordering;
+using Rql.Tests.Common.Factory;
+using System.Linq.Expressions;
+using System.Text.Json;
+using Xunit;
+
+namespace Rql.Tests.Unit.Ordering;
+
+public class CustomPropertyResolverOrderingTests
+{
+    private static OrderingPathInfoBuilder CreateSut(Mock<IExternalServiceAccessor> externalServicesMock)
+    {
+        return new OrderingPathInfoBuilder(
+            new SimpleActionValidator(),
+            MetadataProviderFactory.Internal(),
+            new BuilderContext(),
+            RqlSettingsFactory.Default(),
+            externalServicesMock.Object);
+    }
+
+    private static Mock<IExternalServiceAccessor> RegisterResolver(IRqlCustomPropertyResolver resolver)
+    {
+        var mock = new Mock<IExternalServiceAccessor>();
+        mock.Setup(s => s.GetService(typeof(ITestResolver))).Returns(resolver);
+        return mock;
+    }
+
+    [Fact]
+    public void Build_OrderByResolverPath_SyntheticPermitsOrder_ReturnsResolverExpression()
+    {
+        // Arrange — resolver returns a property that allows Order
+        var leaf = Expression.Constant("ordered", typeof(string));
+        var resolverMock = new Mock<IRqlCustomPropertyResolver>();
+        resolverMock
+            .Setup(r => r.TryResolve(It.IsAny<Expression>(), "dynamicProp", out It.Ref<Expression>.IsAny, out It.Ref<IRqlPropertyInfo>.IsAny))
+            .Returns((Expression parent, string name, out Expression expr, out IRqlPropertyInfo info) =>
+            {
+                expr = leaf;
+                info = CreateSyntheticPropertyInfo(name, RqlActions.Order);
+                return true;
+            });
+
+        var sut = CreateSut(RegisterResolver(resolverMock.Object));
+        var root = Expression.Parameter(typeof(EntityWithJson), "e");
+
+        // Act
+        var result = sut.Build(root, "jsonProp.dynamicProp");
+
+        // Assert — same dispatch as filter, but validates the Order action instead
+        result.IsError.Should().BeFalse();
+        result.Value!.Expression.Should().BeSameAs(leaf);
+        result.Value.PropertyInfo.Name.Should().Be("dynamicProp");
+    }
+
+    [Fact]
+    public void Build_OrderByResolverPath_SyntheticDoesNotPermitOrder_ReturnsOrderingNotPermittedError()
+    {
+        // Arrange — resolver returns a Filter-only property (no Order action)
+        var resolverMock = new Mock<IRqlCustomPropertyResolver>();
+        resolverMock
+            .Setup(r => r.TryResolve(It.IsAny<Expression>(), "dynamicProp", out It.Ref<Expression>.IsAny, out It.Ref<IRqlPropertyInfo>.IsAny))
+            .Returns((Expression parent, string name, out Expression expr, out IRqlPropertyInfo info) =>
+            {
+                expr = Expression.Constant("resolved", typeof(string));
+                info = CreateSyntheticPropertyInfo(name, RqlActions.Filter);
+                return true;
+            });
+
+        var sut = CreateSut(RegisterResolver(resolverMock.Object));
+        var root = Expression.Parameter(typeof(EntityWithJson), "e");
+
+        // Act
+        var result = sut.Build(root, "jsonProp.dynamicProp");
+
+        // Assert — validation surfaces the ordering-specific error message
+        result.IsError.Should().BeTrue();
+        result.Errors.Should().Contain(e => e.Message.Contains("Ordering is not permitted"));
+    }
+
+    [Fact]
+    public void Build_OrderByNestedResolverPath_ForwardsFullDottedKeyToResolver()
+    {
+        // Arrange — exactly like the filter nested test, but exercised through the ordering builder
+        var leaf = Expression.Constant("ordered", typeof(string));
+        var resolverMock = new Mock<IRqlCustomPropertyResolver>();
+        resolverMock
+            .Setup(r => r.TryResolve(It.IsAny<Expression>(), "a.b.c", out It.Ref<Expression>.IsAny, out It.Ref<IRqlPropertyInfo>.IsAny))
+            .Returns((Expression parent, string name, out Expression expr, out IRqlPropertyInfo info) =>
+            {
+                expr = leaf;
+                info = CreateSyntheticPropertyInfo(name, RqlActions.Order);
+                return true;
+            });
+
+        var sut = CreateSut(RegisterResolver(resolverMock.Object));
+        var root = Expression.Parameter(typeof(EntityWithJson), "e");
+
+        // Act
+        var result = sut.Build(root, "jsonProp.a.b.c");
+
+        // Assert
+        result.IsError.Should().BeFalse();
+        result.Value!.PropertyInfo.Name.Should().Be("a.b.c");
+        result.Value.Expression.Should().BeSameAs(leaf);
+    }
+
+    private static IRqlPropertyInfo CreateSyntheticPropertyInfo(string name, RqlActions actions)
+    {
+        var mock = new Mock<IRqlPropertyInfo>();
+        mock.Setup(p => p.Name).Returns(name);
+        mock.Setup(p => p.Type).Returns(RqlPropertyType.Primitive);
+        mock.Setup(p => p.Actions).Returns(actions);
+        mock.Setup(p => p.Operators).Returns(RqlOperators.Eq | RqlOperators.Ne);
+        mock.Setup(p => p.IsNullable).Returns(true);
+        mock.Setup(p => p.Mode).Returns(RqlPropertyMode.Default);
+        return mock.Object;
+    }
+
+    public interface ITestResolver : IRqlCustomPropertyResolver { }
+
+    public class EntityWithJson
+    {
+        [RqlProperty(Actions = RqlActions.Order, CustomResolver = typeof(ITestResolver))]
+        public JsonElement? JsonProp { get; set; }
+    }
+}

--- a/tests/Rql.Tests.Unit/Services/PathInfoBuilderTests.cs
+++ b/tests/Rql.Tests.Unit/Services/PathInfoBuilderTests.cs
@@ -33,8 +33,9 @@ public class PathInfoBuilderTests
             Ordering = { Navigation = orderNav }
         };
 
-        var filtering = new FilteringPathInfoBuilder(actionValidator.Object, metadataProvider, builderContext, opSettings);
-        var ordering = new OrderingPathInfoBuilder(actionValidator.Object, metadataProvider, builderContext, opSettings);
+        var externalServices = Mock.Of<IExternalServiceAccessor>();
+        var filtering = new FilteringPathInfoBuilder(actionValidator.Object, metadataProvider, builderContext, opSettings, externalServices);
+        var ordering = new OrderingPathInfoBuilder(actionValidator.Object, metadataProvider, builderContext, opSettings, externalServices);
         return (filtering, ordering);
     }
 


### PR DESCRIPTION
Allow RQL to filter on dynamic JSON properties stored in JsonElement columns by introducing a pluggable IRqlCustomPropertyResolver extension point.

When PathInfoBuilder fails to resolve a property segment via CLR reflection, it falls back to registered custom resolvers. Each resolver can return an  expression (e.g. a SQL JSON_VALUE call) and a synthetic property descriptor,  allowing RQL's existing operator pipeline to handle eq, ne, like, in etc.  without any custom predicate building.

- Add IRqlCustomPropertyResolver interface in Abstractions
- Modify PathInfoBuilder to try resolvers as fallback, with leaf guard preventing nested dot-navigation after a resolved property
- Wire IEnumerable<IRqlCustomPropertyResolver> through FilteringPathInfoBuilder
- Add 10 unit tests covering resolver dispatch, ordering, leaf guard, action validation, and non-interference with standard CLR paths