### PR TITLE
#MPT-22340 Fix crash on bare wildcard search patterns

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -58,7 +58,7 @@ jobs:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       shell: bash
       run: |
-        .sonar/scanner/dotnet-sonarscanner begin /k:"softwareone-platform_mpt-rql-net" /o:"softwareone-mpt-github" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.opencover.reportsPaths="**/TestResults/**/coverage.opencover.xml"
+        .sonar/scanner/dotnet-sonarscanner begin /k:"softwareone-platform_mpt-rql-net" /o:"softwareone-mpt-github" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.opencover.reportsPaths="**/TestResults/**/coverage.opencover.xml"
       
     - name: Build
       run: dotnet build --no-restore --configuration Release
@@ -73,4 +73,4 @@ jobs:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       shell: bash
       run: |
-        .sonar/scanner/dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
+        .sonar/scanner/dotnet-sonarscanner end

--- a/src/Mpt.Rql/Services/Filtering/Operators/Search/Implementation/Like.cs
+++ b/src/Mpt.Rql/Services/Filtering/Operators/Search/Implementation/Like.cs
@@ -55,12 +55,14 @@ internal class Like(IRqlSettings settings) : ILike
     private static string CleanToLiteralSearchString(string pattern, bool startsWithWildCard, bool startsWithEscapedWildCard,
         bool endsWithEscapedWildCard, bool endsWithWildCard)
     {
-        if (startsWithWildCard) pattern = pattern[1..];
-        else if (startsWithEscapedWildCard) pattern = pattern[1..];
+        var start = startsWithWildCard || startsWithEscapedWildCard ? 1 : 0;
+        var end = pattern.Length;
 
-        if (endsWithEscapedWildCard) pattern = $"{pattern[..^2]}{_wildcard}";
-        else if (endsWithWildCard) pattern = pattern[..^1];
+        if (endsWithEscapedWildCard) end = Math.Max(start, end - 2);
+        else if (endsWithWildCard) end = Math.Max(start, end - 1);
 
-        return pattern;
+        var literal = pattern[start..end];
+
+        return endsWithEscapedWildCard ? $"{literal}{_wildcard}" : literal;
     }
 }

--- a/tests/Rql.Tests.Integration/Tests/Functionality/BasicFilterTests.cs
+++ b/tests/Rql.Tests.Integration/Tests/Functionality/BasicFilterTests.cs
@@ -404,6 +404,51 @@ public class BasicFilterTests
     }
 
     [Theory]
+    [InlineData("like(name,*)")]
+    [InlineData("like(name,**)")]
+    [InlineData("ilike(name,'*')")]
+    public void Like_Name_BareWildcard_MatchesAll(string query)
+    {
+        // Arrange
+        var testData = GetTestData();
+
+        // Act
+        var result = _rql.Transform(testData.AsQueryable(), new RqlRequest { Filter = query });
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        var products = result.Query.ToList();
+        Assert.Equal(testData.Count, products.Count);
+    }
+
+    [Theory]
+    [InlineData(@"like(name,\*)")]
+    public void Like_Name_EscapedWildcardOnly_MatchesLiteralAsterisk(string query)
+    {
+        // Arrange
+        var testData = GetTestData();
+        var literalAsterisk = new Product
+        {
+            Id = 9, Name = "*", Category = "Activity", Price = 1M, SellPrice = 1M, ListDate = DateTime.Now,
+            Desc = "Desc9", Orders = [], OrdersIds = []
+        };
+        // Mirrors the self-referencing wiring GetTestData applies to every product.
+        literalAsterisk.Reference = literalAsterisk;
+        literalAsterisk.Collection = [literalAsterisk, literalAsterisk];
+        literalAsterisk.Tags = [new Tag { Value = $"Tag{literalAsterisk.Id}" }];
+        testData.Add(literalAsterisk);
+
+        // Act
+        var result = _rql.Transform(testData.AsQueryable(), new RqlRequest { Filter = query });
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        var products = result.Query.ToList();
+        Assert.Single(products);
+        Assert.Equal("*", products[0].Name);
+    }
+
+    [Theory]
     [InlineData("like(name,*Widget)")]
     public void Like_Name_EndsWith(string query)
     {


### PR DESCRIPTION
`ilike(field,"*")` returned 400 with a raw .NET error instead of results.

`CleanToLiteralSearchString` trimmed the leading and trailing wildcard markers in
sequence. A pattern that is *only* a marker is both the leading and the trailing
one, so the same characters were consumed twice and the substring length went to
`-1`. Bounds are now resolved before slicing and the end is clamped.