### PR TITLE
#MPT-21890 Report malformed filters as validation errors

### DIFF
--- a/src/Mpt.Rql/Services/Filtering/Builders/ExpressionBuilder.cs
+++ b/src/Mpt.Rql/Services/Filtering/Builders/ExpressionBuilder.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Mpt.Rql.Abstractions;
+using Mpt.Rql.Abstractions.Argument;
 using Mpt.Rql.Abstractions.Binary;
 using Mpt.Rql.Abstractions.Collection;
 using Mpt.Rql.Abstractions.Group;
@@ -26,6 +27,10 @@ internal class ExpressionBuilder : IExpressionBuilder
             RqlBinary binary => Build(pe, binary),
             RqlUnary unary => Build(pe, unary),
             RqlCollection collection => Build(pe, collection),
+            // Arguments are consumed by the binary/collection builders, so reaching here means the
+            // client used a bare value where an expression was expected, e.g. "?query=someBareWord".
+            RqlConstant constant => FilteringError.NotAnExpression(constant.Value),
+            RqlArgument => FilteringError.NotAnExpression(),
             _ => FilteringError.Internal
         };
 

--- a/src/Mpt.Rql/Services/Filtering/Builders/GroupExpressionBuilder.cs
+++ b/src/Mpt.Rql/Services/Filtering/Builders/GroupExpressionBuilder.cs
@@ -27,8 +27,11 @@ internal class GroupExpressionBuilder : IConcreteExpressionBuilder<RqlGroup>
         if (handler.IsError)
             return handler.Errors;
 
+        if (node.Items is null || node.Items.Count == 0)
+            return FilteringError.EmptyGroup;
+
         var errors = new List<Error>();
-        var filter = _builder.Build(pe, node.Items![0]);
+        var filter = _builder.Build(pe, node.Items[0]);
 
         if (filter.IsError)
             errors.AddRange(filter.Errors);

--- a/src/Mpt.Rql/Services/Filtering/FilteringError.cs
+++ b/src/Mpt.Rql/Services/Filtering/FilteringError.cs
@@ -5,4 +5,8 @@ namespace Mpt.Rql.Services.Filtering;
 internal static class FilteringError
 {
     public static Error Internal { get; } = Error.General("Internal filtering error occurred. Please contact RQL package maintainer.", "internal");
+
+    public static Error EmptyGroup { get; } = Error.Validation("Expression group cannot be empty.");
+
+    public static Error NotAnExpression(string? token = null) => Error.Validation("Expression expected.", path: token);
 }

--- a/tests/Rql.Tests.Integration/Tests/Functionality/NegativeFilterTests.cs
+++ b/tests/Rql.Tests.Integration/Tests/Functionality/NegativeFilterTests.cs
@@ -1,4 +1,5 @@
 ﻿using Mpt.Rql;
+using Mpt.Rql.Abstractions.Result;
 using Rql.Tests.Integration.Core;
 using Xunit;
 
@@ -32,5 +33,49 @@ public class NegativeFilterTests
         // Assert
         Assert.False(result.IsSuccess);
         Assert.Contains("Invalid property path.", result.Errors.First().Message);
+    }
+
+    [Theory]
+    [InlineData("someBareWord")]
+    [InlineData("name")]
+    [InlineData("123")]
+    [InlineData("*")]
+    [InlineData("reference.name")]
+    [InlineData("(someBareWord)")]
+    [InlineData("and(someBareWord)")]
+    [InlineData("not(someBareWord)")]
+    [InlineData("or(name,eq(price,1))")]
+    [InlineData("and(eq(price,1),bareWord)")]
+    [InlineData("any(Orders,bareWord)")]
+    public void BareValue_UsedAsExpression_ReturnsValidationError(string query)
+    {
+        // Arrange
+        var testData = ProductRepository.Query();
+
+        // Act
+        var result = _rql.Transform(testData, new RqlRequest { Filter = query });
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.All(result.Errors, e => Assert.Equal(ErrorType.Validation, e.Type));
+        Assert.DoesNotContain(result.Errors, e => e.Message.Contains("RQL package maintainer"));
+    }
+
+    [Theory]
+    [InlineData("()")]
+    [InlineData("and()")]
+    [InlineData("and(,)")]
+    public void EmptyExpressionGroup_ReturnsValidationError(string query)
+    {
+        // Arrange
+        var testData = ProductRepository.Query();
+
+        // Act
+        var result = _rql.Transform(testData, new RqlRequest { Filter = query });
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.All(result.Errors, e => Assert.Equal(ErrorType.Validation, e.Type));
+        Assert.DoesNotContain(result.Errors, e => e.Message.Contains("RQL package maintainer"));
     }
 }


### PR DESCRIPTION
## Problem

`?query=someBareWord` — a bare value where an expression is expected — produced:

> Internal filtering error occurred. Please contact RQL package maintainer.

Nothing internal is broken and there is no inner exception. The message is misdirection for what is simply an invalid client filter.

The value reaches [`ExpressionBuilder`](src/Mpt.Rql/Services/Filtering/Builders/ExpressionBuilder.cs) as an `RqlArgument`, matches none of `RqlGroup`/`RqlBinary`/`RqlUnary`/`RqlCollection`, and falls into `_ => FilteringError.Internal`. That is an `Error.General` rather than an `Error.Validation`, so the consuming framework routes it to `ThrowRqlUnexpectedException` instead of the normal validation path. It already returns HTTP 400 — the status was never wrong, only the wording.

Confirmed reproducing filters, all of which returned the misleading error:

`someBareWord` · `name` · `123` · `*` · `reference.name` · `(someBareWord)` · `and(someBareWord)` · `not(someBareWord)` · `or(name,eq(price,1))` · `and(eq(price,1),bareWord)` · `any(Orders,bareWord)`

Note the nested cases: the single-item unwrap in `FilteringService` is **not** the only route, so guarding that alone would not have fixed this.

## Changes

- **`FilteringError`** — added `NotAnExpression(token)` and `EmptyGroup`, keeping error text centralized.
- **`ExpressionBuilder`** — new `RqlConstant` and `RqlArgument` arms returning a validation error, with the offending token carried as the error `path`. `FilteringError.Internal` is now reserved for genuinely unreachable shapes. Arguments are consumed by the binary and collection builders, so no legitimate flow passes one here (verified against every caller of `IExpressionBuilder.Build`: root, group items, `RqlNot.Nested`).
- **`GroupExpressionBuilder`** — empty-group guard. `()`, `and()` and `and(,)` indexed `Items[0]` unconditionally and threw `ArgumentOutOfRangeException`, which escapes the `RqlFailureException` mapping and surfaces as a **500**. This was a separate, more severe defect found while investigating. The guard sits after the handler switch so unknown groups keep the more specific `"Unknown expression group."` error. The now-redundant `Items![0]` null-forgiving operator is removed.

Resulting behavior:

| filter | before | after |
|---|---|---|
| `someBareWord` | General/`internal`, "contact RQL package maintainer" | Validation, `path='someBareWord'`, `"Expression expected."` |
| `and(eq(price,1),bareWord)` | same misleading General error | Validation on `bareWord` only — the valid operand still builds |
| `()`, `and()`, `and(,)` | `ArgumentOutOfRangeException` → 500 | Validation, `"Expression group cannot be empty."` |
| `unknownfn(name,1)` | Validation, `"Unknown expression group."` | unchanged |

## Tests

14 regression tests added to `NegativeFilterTests`, covering every reproducing shape and asserting `ErrorType.Validation` plus absence of the "RQL package maintainer" text. Written before the fix and confirmed failing with `Expected: Validation / Actual: General`.

Full suite: **205 integration + 402 unit, 0 failures**.

## Follow-ups, deliberately not in this PR

`RqlParserException`, propagating uncaught out of `FilteringService.Process` as client-reachable 500s. Converting the parser from throwing to the `Result`/`Error` model is a substantially larger change and belongs in its own ticket.
