### PR TITLE
Guard against zero-argument collection expressions in RqlCollectionParser

### DIFF
--- a/src/Mpt.Rql/Parsers/Linear/Services/RqlCollectionParser.cs
+++ b/src/Mpt.Rql/Parsers/Linear/Services/RqlCollectionParser.cs
@@ -16,6 +16,9 @@ internal static class RqlCollectionParser
 
     internal static RqlExpression Parse(string term, IList<ExpressionPair> innerExpressionPairs)
     {
+        if (innerExpressionPairs.Count == 0)
+            throw new RqlCollectionParserException("Collection expression must have at least 1 argument");
+
         var left = innerExpressionPairs[0].Expression;
 
         if (!_expressionFunctionMap.TryGetValue(term, out var resolvedExpression))

--- a/tests/Rql.Tests.Integration/Tests/Functionality/NegativeFilterTests.cs
+++ b/tests/Rql.Tests.Integration/Tests/Functionality/NegativeFilterTests.cs
@@ -1,4 +1,5 @@
 ﻿using Mpt.Rql;
+using Mpt.Rql.Abstractions.Exception;
 using Rql.Tests.Integration.Core;
 using Xunit;
 
@@ -32,5 +33,20 @@ public class NegativeFilterTests
         // Assert
         Assert.False(result.IsSuccess);
         Assert.Contains("Invalid property path.", result.Errors.First().Message);
+    }
+
+    [Theory]
+    [InlineData("any()")]
+    [InlineData("all()")]
+    public void Collection_WithoutArguments_ThrowsRqlCollectionParserException(string query)
+    {
+        // Arrange
+        var testData = ProductRepository.Query();
+
+        // Act and Assert
+        var exception = Assert.Throws<RqlCollectionParserException>(() =>
+            _rql.Transform(testData, new RqlRequest { Filter = query }));
+
+        Assert.Equal("Collection expression must have at least 1 argument", exception.Message);
     }
 }


### PR DESCRIPTION
Fixes #31

## Problem

`RqlCollectionParser.Parse` indexed `innerExpressionPairs[0]` with no arity guard, so the zero-argument filters `any()` and `all()` crashed with a raw `System.ArgumentOutOfRangeException`. Because that is not an `Rql*ParserException`, it escaped the consuming framework's `RqlFailureException` → HTTP 400 mapping and surfaced to callers as a **500**.

Reproduced at `88c80e3` before making any change:

```
Assert.Throws() Failure: Exception type was not an exact match
Expected: typeof(Mpt.Rql.Abstractions.Exception.RqlCollectionParserException)
Actual:   typeof(System.ArgumentOutOfRangeException)
---- System.ArgumentOutOfRangeException : Index was out of range.
   at Mpt.Rql.Parsers.Linear.Services.RqlCollectionParser.Parse(...) in RqlCollectionParser.cs:line 19
```

## Change

One guard in `RqlCollectionParser.Parse`, mirroring the sibling parsers (`RqlBinaryParser.cs:28`, `RqlUnaryParser.cs:14`) in both wording and placement — arity check ahead of the term lookup:

```csharp
if (innerExpressionPairs.Count == 0)
    throw new RqlCollectionParserException("Collection expression must have at least 1 argument");
```

The condition is `== 0` only, so the legitimate one-argument form is untouched:

- `any(Orders)` stays valid — `RqlCollectionParser.cs:24` already treats a missing second argument as `null`. Covered by the existing `Any_Orders` test in `BasicFilterTests.cs:833`, still green.
- `all(Orders)` stays a *validation error* from `All.cs:15`, not a parser exception.

## Tests

Added `Collection_WithoutArguments_ThrowsRqlCollectionParserException` to `NegativeFilterTests.cs`, covering `any()` and `all()`. Confirmed red before the fix, green after.

Full suite from repo root: **193 integration + 402 unit, 0 failures** (baseline 191 + 402; the 2 new cases account for the delta).

## Reviewer note

No parser exception is caught anywhere in `src/` — the library's only `catch` is in `ConstantHelper.cs` — so `RqlCollectionParserException` propagates out of `Transform` rather than landing in `result.Errors`. That matches how `RqlBinaryParserException` and `RqlUnaryParserException` already behave and is what the 400 mapping keys off, so the test asserts `Assert.Throws` rather than `IsSuccess == false`. Turning these three into graph validation errors instead would be a broader, separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
