### PR TITLE
#MPT-24378 Guard against zero-argument collection expressions

### DIFF
--- a/src/Mpt.Rql/Parsers/Linear/Services/RqlCollectionParser.cs
+++ b/src/Mpt.Rql/Parsers/Linear/Services/RqlCollectionParser.cs
@@ -16,6 +16,9 @@ internal static class RqlCollectionParser
 
     internal static RqlExpression Parse(string term, IList<ExpressionPair> innerExpressionPairs)
     {
+        if (innerExpressionPairs.Count == 0)
+            throw new RqlCollectionParserException("Collection expression must have at least 1 argument");
+
         var left = innerExpressionPairs[0].Expression;
 
         if (!_expressionFunctionMap.TryGetValue(term, out var resolvedExpression))

--- a/tests/Rql.Tests.Integration/Tests/Functionality/NegativeFilterTests.cs
+++ b/tests/Rql.Tests.Integration/Tests/Functionality/NegativeFilterTests.cs
@@ -1,4 +1,5 @@
 ﻿using Mpt.Rql;
+using Mpt.Rql.Abstractions.Exception;
 using Mpt.Rql.Abstractions.Result;
 using Rql.Tests.Integration.Core;
 using Xunit;
@@ -77,5 +78,20 @@ public class NegativeFilterTests
         Assert.False(result.IsSuccess);
         Assert.All(result.Errors, e => Assert.Equal(ErrorType.Validation, e.Type));
         Assert.DoesNotContain(result.Errors, e => e.Message.Contains("RQL package maintainer"));
+    }
+
+    [Theory]
+    [InlineData("any()")]
+    [InlineData("all()")]
+    public void Collection_WithoutArguments_ThrowsRqlCollectionParserException(string query)
+    {
+        // Arrange
+        var testData = ProductRepository.Query();
+
+        // Act and Assert
+        var exception = Assert.Throws<RqlCollectionParserException>(() =>
+            _rql.Transform(testData, new RqlRequest { Filter = query }));
+
+        Assert.Equal("Collection expression must have at least 1 argument", exception.Message);
     }
 }


### PR DESCRIPTION
`any()` and `all()` returned 500 with a raw .NET error instead of a 400.

`RqlCollectionParser.Parse` indexed `innerExpressionPairs[0]` with no arity guard, so a
zero-argument collection filter crashed with `ArgumentOutOfRangeException`. Not being an
`Rql*ParserException`, it escaped the consuming framework's `RqlFailureException` to HTTP
400 mapping. An arity guard now throws `RqlCollectionParserException`, mirroring the
existing guards in `RqlBinaryParser` and `RqlUnaryParser` in both wording and placement.

The check is `Count == 0` only, so the legitimate one-argument form is untouched:
`any(Orders)` stays valid, since line 24 already treats a missing second argument as
`null`, and `all(Orders)` stays a validation error from `All.cs:15` rather than a parser
exception. The existing `Any_Orders` test at `BasicFilterTests.cs:833` covers that and is
still green.

Regression tests for `any()` and `all()` added to `NegativeFilterTests` alongside the
`EmptyExpressionGroup_ReturnsValidationError` theory from #30, confirmed red before the fix
and green after. Full suite: 207 integration + 402 unit, 0 failures (baseline 205 + 402).

This is the collection-parser half of the follow-up #30 flagged in its own commit message:
"Parser-level exceptions (`eq(name)`, `name=`) still propagate uncaught and are left for a
separate change." Consistent with that, this throws rather than returning an
`Error.Validation` like `FilteringError.EmptyGroup` does — the guard sits at the parser
layer, which has no error-collecting channel, and no parser exception is caught anywhere in
`src/` (the library's only `catch` is in `ConstantHelper.cs`). So it propagates out of
`Transform` and the test asserts `Assert.Throws`, not `IsSuccess == false`. Converting all
three parsers to validation errors remains the larger separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
