### PR TITLE
#MPT-21890 Report ordering validation path in Error.Path

### DIFF
--- a/src/Mpt.Rql/Services/Ordering/OrderingPathInfoBuilder.cs
+++ b/src/Mpt.Rql/Services/Ordering/OrderingPathInfoBuilder.cs
@@ -18,7 +18,7 @@ internal class OrderingPathInfoBuilder(IActionValidator actionValidator, IMetada
     protected override Result<bool> ValidatePath(RqlPropertyInfo property, string path)
     {
         if (!_actionValidator.Validate(property, RqlActions.Order))
-            return Error.Validation("Ordering is not permitted.", _builderContext.GetFullPath(path));
+            return Error.Validation("Ordering is not permitted.", path: _builderContext.GetFullPath(path));
         return true;
     }
 


### PR DESCRIPTION
## Problem

`OrderingPathInfoBuilder.ValidatePath` built its "Ordering is not permitted." error like this:

```csharp
return Error.Validation("Ordering is not permitted.", _builderContext.GetFullPath(path));
```

`Error.Validation` is declared as `Validation(string message, string? code = null, string? path = null)`, so the offending field path was landing in `Error.Code` and `Error.Path` was left `null`.

## Fix

Pass the path as a named argument:

```csharp
return Error.Validation("Ordering is not permitted.", path: _builderContext.GetFullPath(path));
```

## Consumer impact

None. The only consumer of these two fields is `Mpt.Framework.Application.Query.QueryService.ThrowRqlException`, which resolves the `ValidationFailure` property name as `s.Path ?? s.Code` — so the name it produces is unchanged either way. This is a correctness fix for anything that reads the fields individually.

## Tests

No test changes needed — nothing asserts on `Error.Code` for the ordering path. The two tests covering this error match on `Message` only (`BasicActionStrategyTests.cs:100`, `CustomPropertyResolverOrderingTests.cs:83`).

`dotnet test`: **0 failed** — 205 integration, 402 unit.

## Related

The identical mistake exists at two more call sites — `Core/PathInfoBuilder.cs:111` (`"Invalid property path."`) and `Services/Filtering/FilteringPathInfoBuilder.cs:21` (`"Filtering is not permitted."`). Those are being fixed on a separate branch, which also has to flip `tests/Rql.Tests.Unit/Filtering/CustomPropertyResolverTests.cs:200` from `error.Code` to `error.Path`. There is no overlap with this PR, but the two need to land together for the fix to be complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
