### PR TITLE
#MPT-24376 Report field path in Error.Path, not Error.Code

### DIFF
--- a/src/Mpt.Rql/Core/PathInfoBuilder.cs
+++ b/src/Mpt.Rql/Core/PathInfoBuilder.cs
@@ -108,7 +108,7 @@ internal abstract class PathInfoBuilder(IMetadataProvider metadataProvider, IBui
 
         Result<PathWalkState> CreateInvalidPathValidationError(string invalidPath)
         {
-            return Error.Validation("Invalid property path.", builderContext.GetFullPath(invalidPath));
+            return Error.Validation("Invalid property path.", path: builderContext.GetFullPath(invalidPath));
         }
     }
 

--- a/src/Mpt.Rql/Services/Filtering/FilteringPathInfoBuilder.cs
+++ b/src/Mpt.Rql/Services/Filtering/FilteringPathInfoBuilder.cs
@@ -18,7 +18,7 @@ internal class FilteringPathInfoBuilder(IActionValidator actionValidator, IMetad
     protected override Result<bool> ValidatePath(RqlPropertyInfo property, string path)
     {
         if (!_actionValidator.Validate(property, RqlActions.Filter))
-            return Error.Validation("Filtering is not permitted.", _builderContext.GetFullPath(path));
+            return Error.Validation("Filtering is not permitted.", path: _builderContext.GetFullPath(path));
         return true;
     }
 

--- a/src/Mpt.Rql/Services/Ordering/OrderingPathInfoBuilder.cs
+++ b/src/Mpt.Rql/Services/Ordering/OrderingPathInfoBuilder.cs
@@ -18,7 +18,7 @@ internal class OrderingPathInfoBuilder(IActionValidator actionValidator, IMetada
     protected override Result<bool> ValidatePath(RqlPropertyInfo property, string path)
     {
         if (!_actionValidator.Validate(property, RqlActions.Order))
-            return Error.Validation("Ordering is not permitted.", _builderContext.GetFullPath(path));
+            return Error.Validation("Ordering is not permitted.", path: _builderContext.GetFullPath(path));
         return true;
     }
 

--- a/tests/Rql.Tests.Unit/Filtering/CustomPropertyResolverTests.cs
+++ b/tests/Rql.Tests.Unit/Filtering/CustomPropertyResolverTests.cs
@@ -197,7 +197,7 @@ public class CustomPropertyResolverTests
         result.IsError.Should().BeTrue();
         var error = result.Errors.Single();
         error.Message.Should().Contain("Filtering is not permitted");
-        error.Code.Should().Contain("jsonProp.a.b.c");
+        error.Path.Should().Contain("jsonProp.a.b.c");
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

[`Error.Validation`](src/Mpt.Rql.Abstractions/Result/Error.cs) is declared:

```csharp
public static Error Validation(string message, string? code = null, string? path = null)
```

Three call sites passed the field path as the second **positional** argument, so it landed in `code`:

- [`PathInfoBuilder.cs:111`](src/Mpt.Rql/Core/PathInfoBuilder.cs) — `Error.Validation("Invalid property path.", builderContext.GetFullPath(invalidPath))`
- [`FilteringPathInfoBuilder.cs:21`](src/Mpt.Rql/Services/Filtering/FilteringPathInfoBuilder.cs) — `Error.Validation("Filtering is not permitted.", _builderContext.GetFullPath(path))`
- [`OrderingPathInfoBuilder.cs:21`](src/Mpt.Rql/Services/Ordering/OrderingPathInfoBuilder.cs) — `Error.Validation("Ordering is not permitted.", _builderContext.GetFullPath(path))`

The filter `eq(nosuchprop,1)` produced:

```
Type=Validation  Code='nosuchprop'  Path=''
```

So the property path was reported as the error *code*, `Path` was empty, and `Code` lost its intended `rql_validation` default. [`GroupExpressionBuilder.cs:23`](src/Mpt.Rql/Services/Filtering/Builders/GroupExpressionBuilder.cs) already had this right, using the named `path:` argument — as does the `ExpressionBuilder` work from #30.

## Changes

All three call sites now use the named `path:` argument. `Code` keeps `rql_validation`; `Path` carries the field path.

| filter | before | after |
|---|---|---|
| `eq(nosuchprop,1)` | `Code='nosuchprop'`, `Path=''` | `Code='rql_validation'`, `Path='nosuchprop'` |

## Consumer impact — none observable

This changes the published package's error shape, so consumers were checked before touching it.

The only code that reads these fields is `QueryService.ThrowRqlException` in `Mpt.Framework.Application` ([`QueryServiceT.cs:256`](https://github.com/softwareone-platform/mpt-library-framework)):

```csharp
new FluentValidation.Results.ValidationFailure(s.Path ?? s.Code, s.Message)
```

The coalesce yields the field path both before and after this change, so the HTTP-level validation response is byte-identical. That fallback looks like it was written to tolerate exactly this.

Other consumers of `Mpt.Rql.Abstractions.Result` across the org were checked and are unaffected:

- `mpt-extensions` / `RqlSdkFilterService` — structured-logs the whole `Error` object; both fields serialize either way.
- `mpt-audit` / `Rql/LikeSearch` — only *produces* errors, never reads `Code`.
- `swo-platform` — no direct use. Its `PlatformExceptionHandler` reads `x.Code` off `DomainModelError`, an unrelated type.

## Tests

One existing unit test asserted the wrong placement — `CustomPropertyResolverTests.cs:200` checked `error.Code` for the dotted path. Its own comment states the intent is that *"the error location must reference the FULL dotted path"*, so the assertion moves to `error.Path`, preserving intent. `NegativeFilterTests` asserts only on `Message` and is unaffected.

Full suite: **205 integration + 402 unit, 0 failures**.

Resolves [MPT-24376](https://softwareone.atlassian.net/browse/MPT-24376).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MPT-24376]: https://softwareone.atlassian.net/browse/MPT-24376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
